### PR TITLE
Perf. improvement - save the gather result into dst directly if dst is contiguous (copy_kernel_mps)

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -51,8 +51,7 @@ std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value
 double getMPSScalarValue(const Tensor& t);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
-Tensor gatherViewTensor(const at::Tensor& src);
-Tensor gatherViewTensorWithOutput(const at::Tensor& src, at::Tensor& dst);
+Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
 Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output);
 
 MPSShape* getMPSShape(const Tensor& t);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -52,6 +52,7 @@ double getMPSScalarValue(const Tensor& t);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src);
+Tensor gatherViewTensorWithOutput(const at::Tensor& src, at::Tensor& dst);
 Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output);
 
 MPSShape* getMPSShape(const Tensor& t);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -257,8 +257,9 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSS
   id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
   // a view tensor could be contiguous (e.g., slice ops) or non-contiguous (e.g., transpose())
   if (src.is_view() || !src.is_contiguous()) {
+     Tensor emptyShell = Tensor();
     // use "_tensor" from Placeholder to retain view's output during its usage in other ops
-    _tensor = gatherViewTensor(src);
+    _tensor = gatherViewTensor(src, emptyShell);
     if (!_tensor.has_storage()) {
       // if we cannot gather, we make the the tensor contiguous implicitly, and keep
       // it in placeholder to be able to retrieve it when we return from constructor

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -101,7 +101,8 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 
   auto storage_byte_offset = src_.storage_offset() * src_.itemsize();
   if (!src_.is_contiguous()) {
-    src = gatherViewTensor(src_);
+    Tensor emptyShell = Tensor();
+    src = gatherViewTensor(src_, emptyShell);
     if (src.has_storage()) {
       storage_byte_offset = 0;
     } else {
@@ -258,12 +259,10 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   Tensor src;
 
   if (!src_.is_contiguous()) {
-    src = returnGatherOutput ?
-      gatherViewTensorWithOutput(src_, dst_) :
-      gatherViewTensor(src_);
+    Tensor emptyShell = Tensor();
+    src = gatherViewTensor(src_, returnGatherOutput ? dst_ : emptyShell);
 
     if (src.has_storage()) {
-
       if (returnGatherOutput)
         return dst_;
 

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -250,10 +250,23 @@ void copy_blit_mps(void* dst, const void* src, size_t size) {
 static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking)
 {
   auto src_byte_offset = src_.storage_offset() * src_.itemsize();
+  auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
+
+  // If dst is contiguous and there is no byte offset, we can save directly the result of
+  // gather into dst. This reduces the overhead of doing an additional blit for most cases
+  bool returnGatherOutput = (dst_.is_contiguous() && !dst_byte_offset);
   Tensor src;
+
   if (!src_.is_contiguous()) {
-    src = gatherViewTensor(src_);
+    src = returnGatherOutput ?
+      gatherViewTensorWithOutput(src_, dst_) :
+      gatherViewTensor(src_);
+
     if (src.has_storage()) {
+
+      if (returnGatherOutput)
+        return dst_;
+
       src_byte_offset = 0;
     } else {
       src = src_.expand_as(dst_).contiguous();
@@ -271,7 +284,6 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   src._set_conj(src_.is_conj());
   src._set_neg(src_.is_neg());
 
-  auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
   id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
   id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
   const size_t src_size = src.nbytes();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4641,7 +4641,7 @@ class TestGatherScatter(TestCase):
         x_mps = torch.zeros(10, dtype=torch.float32, device="mps")
         x_mps[::2] = 1.0
 
-        x_cpu = torch.zeros(10, dtype=torch.float32, device="mps")
+        x_cpu = torch.zeros(10, dtype=torch.float32, device="cpu")
         x_cpu[::2] = 1.0
 
         self.assertEqual(x_cpu, x_mps)


### PR DESCRIPTION
Performance improvement for copy_kernel_mps .

If dst is contiguous and there is no byte offset, we can save directly the result of gather into dst. This reduces the overhead of doing an additional blit for most cases.