### PR TITLE
Build the indexing library with the correct Metal version

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -59,6 +59,10 @@ bool dispatchIndexSelectKernel(TensorIteratorBase& iter, IntArrayRef index_size,
   using namespace mps;
 
   @autoreleasepool {
+    if (iter.numel() == 0) {
+      return true;
+    }
+
     const Tensor& inputTensor = iter.tensor(1);
     Tensor outputTensor = iter.tensor(0);
 


### PR DESCRIPTION
Build the indexing library with the correct Metal version
Default version is 1.2 if not specified on x86