### PR TITLE
Add memory allocation limit, and use fillBuffer() for zero_mps()

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -38,17 +38,18 @@ namespace mps {
 //  MPSStream
 //-----------------------------------------------------------------
 
+enum class SyncType {
+  NONE,               // no commit to command buffer
+  COMMIT,             // commit and flush the command buffer
+  COMMIT_AND_WAIT,    // flush and wait for command buffer execution to finish
+  COMMIT_AND_CONTINUE,// commit and continue with a new underlying command buffer
+};
+
 class TORCH_API MPSStream
 {
 public:
   enum Unchecked { UNCHECKED };
 
-  enum class SyncType {
-    NONE,               // no commit to command buffer
-    COMMIT,             // commit and flush the command buffer
-    COMMIT_AND_WAIT,    // flush and wait for command buffer execution to finish
-    COMMIT_AND_CONTINUE,// commit and continue with a new underlying command buffer
-  };
   /// Construct a MPSStream from a Stream.  This construction is checked,
   /// and will raise an error if the Stream is not, in fact, a MPS stream.
   explicit MPSStream(Stream stream);
@@ -57,11 +58,12 @@ public:
   MTLCommandQueue_t commandQueue() const { return _commandQueue; };
   dispatch_queue_t queue() const { return _serialQueue; }
 
-  MTLCommandBuffer_t commandBuffer();
+  MPSCommandBuffer* commandBuffer();
   void commit(bool flush);
   void commitAndWait();
   void commitAndContinue();
-  void synchronize();
+  void synchronize(SyncType syncType);
+  void fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
   void copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
             size_t length, size_t srcOffset, size_t dstOffset, SyncType syncType = SyncType::NONE);
   void copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -14,7 +14,7 @@ namespace mps {
 MPSStream::MPSStream(Stream stream) : _stream(stream) {
   _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
   TORCH_CHECK(_stream.device_type() == DeviceType::MPS);
-  _serialQueue = dispatch_queue_create("metal gpu stream", NULL);
+  _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
   _executionDescriptor = [MPSGraphExecutionDescriptor new];
   _executionDescriptor.completionHandler = ^(NSDictionary<MPSGraphTensor *,
                                              MPSGraphTensorData *> * resultsDictionary,
@@ -29,22 +29,29 @@ MPSStream::~MPSStream() {
   assert(_commandBuffer == nil);
 }
 
-id<MTLCommandBuffer> MPSStream::commandBuffer() {
+MPSCommandBuffer* MPSStream::commandBuffer() {
   if (!_commandBuffer) {
-    _commandBuffer =
-        [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
+    _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
   }
 
   return _commandBuffer;
 }
 
-void MPSStream::synchronize() {
-  dispatch_sync(queue(), ^() {
-    @autoreleasepool {
-      commandBuffer();
+void MPSStream::synchronize(SyncType syncType) {
+  switch(syncType) {
+    case SyncType::NONE:
+      // typically in GPU to GPU copies we won't commit explicitly
+      break;
+    case SyncType::COMMIT:
+      commit(true);
+      break;
+    case SyncType::COMMIT_AND_WAIT:
       commitAndWait();
-    }
-  });
+      break;
+    case SyncType::COMMIT_AND_CONTINUE:
+      commitAndContinue();
+      break;
+  }
 }
 
 void MPSStream::commit(bool doFlush) {
@@ -87,6 +94,22 @@ void MPSStream::_flush(bool commitAndWait) const {
   [_commandBuffer release];
 }
 
+void MPSStream::fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType)
+{
+  if (length == 0) return;
+  dispatch_sync(_serialQueue, ^() {
+    @autoreleasepool {
+      id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
+
+      [blitEncoder fillBuffer:buffer
+                        range:NSMakeRange(offset, length)
+                        value:value];
+      [blitEncoder endEncoding];
+      synchronize(syncType);
+    }
+  });
+}
+
 void MPSStream::copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                     size_t length, size_t srcOffset, size_t dstOffset, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
@@ -99,20 +122,7 @@ void MPSStream::copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                 destinationOffset:(NSUInteger)dstOffset
                              size:(NSUInteger)length];
       [blitEncoder endEncoding];
-      switch(syncType) {
-        case SyncType::NONE:
-          // typically in GPU to GPU copies we won't commit explicitly
-          break;
-        case SyncType::COMMIT:
-          commit(true);
-          break;
-        case SyncType::COMMIT_AND_WAIT:
-          commitAndWait();
-          break;
-        case SyncType::COMMIT_AND_CONTINUE:
-          commitAndContinue();
-          break;
-      }
+      synchronize(syncType);
     }
   });
 }

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -47,7 +47,7 @@ MPSDataType getMPSDataType(ScalarType scalar_type);
 MPSDataType getMPSScalarType(ScalarType scalar_type);
 std::string getMPSTypeString(ScalarType scalar_type);
 std::string getMPSShapeString(MPSShape* shape);
-std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value = true);
+std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value = false);
 double getMPSScalarValue(const Tensor& t);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -153,9 +153,10 @@ void div_mode_template(const Tensor& self, const Tensor& other,
 
 void add_sub_template(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output, std::string op_name)
 {
-  if (alpha.toDouble() == 0.0)
+  if (alpha.toDouble() == 0.0) {
     const_cast<Tensor&>(output) = self.clone();
-
+    return;
+  }
   const bool alpha_has_value = alpha.toDouble() != 1.0;
   if (alpha_has_value) {
     auto commonDtype = at::result_type(self, other);

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -1,17 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 
-#include <ATen/ATen.h>
-#include <ATen/Tensor.h>
-#include <ATen/Utils.h>
-#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <torch/library.h>
-
-#ifdef __OBJC__
-#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#endif
-
-using namespace at::mps;
 
 namespace at {
 namespace native {
@@ -34,13 +23,7 @@ Tensor& fill_scalar_mps_impl(Tensor& self, const Scalar& value) {
   MPSGraphCache *cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
-
-    MPSShape* input_shape = getMPSShape(self);
-    NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
-
-    string key = "fill_scalar_mps_impl:" + getMPSTypeString(self.scalar_type())
-                                         + ":" + string([ns_shape_key UTF8String])
-                                         + ":" + to_string(value.toDouble());
+    string key = "fill_scalar_mps_impl" + getTensorsStringKey(self) + ":" + to_string(value.toDouble());
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
     if(!cachedGraph) {
 
@@ -52,7 +35,7 @@ Tensor& fill_scalar_mps_impl(Tensor& self, const Scalar& value) {
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* inputTensor = [mpsGraph constantWithScalar:value.toDouble()
-                                                               shape:input_shape
+                                                               shape:getMPSShape(self)
                                                             dataType:getMPSScalarType(self.scalar_type())];
           MPSGraphTensor* outputTensor = [mpsGraph identityWithTensor:inputTensor
                                                                  name:nil];
@@ -79,16 +62,25 @@ Tensor& fill_scalar_mps_impl(Tensor& self, const Scalar& value) {
 }
 
 Tensor& zero_mps_(Tensor& self) {
-  return at::native::fill_scalar_mps_impl(self, 0.0f);
+  if (self.is_contiguous()) {
+    MPSStream* stream = getCurrentMPSStream();
+    auto storage_byte_offset = self.storage_offset() * self.itemsize();
+    stream->fill(mps::getMTLBufferStorage(self), 0, self.nbytes(), storage_byte_offset);
+    return self;
+  }
+  return fill_scalar_mps_impl(self, 0.0f);
 }
 
 Tensor& fill_scalar_mps(Tensor& self, const Scalar& value) {
-  return at::native::fill_scalar_mps_impl(self, value);
+  if (value.toDouble() == 0.0) return zero_mps_(self);
+  return fill_scalar_mps_impl(self, value);
 }
 
 Tensor& fill_tensor_mps_(Tensor& self, const Tensor& value) {
   TORCH_CHECK(value.dim() == 0, "fill_ only supports 0-dimension value tensor but got tensor with ", value.dim(), " dimensions.");
-  return at::native::fill_scalar_mps_impl(self, value.item());
+  Scalar scalar_value = value.item();
+  if (scalar_value.toDouble() == 0.0) return zero_mps_(self);
+  return fill_scalar_mps_impl(self, scalar_value);
 }
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -2,19 +2,9 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/Resize.h>
+#include <ATen/mps/MPSAllocator.h>
 
 namespace at {
-
-// these are from MPSAllocator
-namespace mps {
-  // to check the requested non-aligned size of an MTL buffer
-  ssize_t get_requested_buffer_size(void* ptr);
-  // to retrieve the shape of a base tensor from a view tensor
-  IntArrayRef get_buffer_shape(void* ptr);
-  // to set the shape of a base tensor from a view tensor
-  void set_buffer_shape(void* ptr, const IntArrayRef& shape);
-}
-
 namespace native {
 namespace mps {
 


### PR DESCRIPTION
- Use a separate Scalar pool for getMPSGraphTensorFromScalar()
- Fix minor bug in add_sub_template() with value=0.0
- Change default value of use_scalar_value to false in getTensorsStringKey()

