### PR TITLE
Fix placeholder case for missing gather graph

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -247,7 +247,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSS
     if (!_tensor.has_storage()) {
       // if we cannot gather, we make the the tensor contiguous implicitly, and keep
       // it in placeholder to be able to retrieve it when we return from constructor
-      _tensor = src.contiguous();
+      _tensor = src.clone();
     }
     srcBuf = getMTLBufferStorage(_tensor);
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1290,6 +1290,29 @@ class TestMPS(TestCase):
         mps_slice4 = mps_x[1, :].to('cpu')
         self.assertEqual(cpu_slice4, mps_slice4)
 
+    def test_scalar_from_slice_unary(self):
+        # https://github.com/pytorch/pytorch/issues/82543
+        tensor_list = torch.tensor([1.0, 1.2], device="mps")
+
+        for scalar in tensor_list:
+            r_mps = torch.ceil(scalar)
+            r_cpu = torch.ceil(scalar.to("cpu"))
+            self.assertEqual(r_mps.cpu(), r_cpu)
+
+    def test_scalar_from_slice_binary(self):
+        # https://github.com/pytorch/pytorch/issues/82543
+        def helper(binary_op):
+            tensor_list = torch.tensor([1.0, 1.2, 2.5, 1.0], device="mps")
+
+            for scalar in tensor_list:
+                r_mps = binary_op(scalar, 1.0)
+                r_cpu = binary_op(scalar.cpu(), 1.0)
+                self.assertEqual(r_mps.cpu(), r_cpu)
+        helper(torch.sub)
+        helper(torch.add)
+        helper(torch.not_equal)
+        helper(torch.eq)
+
     def test_slice_contiguous_view(self):
         # https://github.com/pytorch/pytorch/issues/77750
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/82543

The current Placeholder code relies to find a gather graph in order to make the data `contiguous`, otherwise we'll try calling into `tensor.contiguous()` directly, which for slice elements, won't do anything.

E.g  consider the following basic case where we index a 2 element tensor:
```
tensor_list = torch.tensor([1.2, 1.0], device="mps")

for scalar in tensor_list:
  r_mps = torch.ceil(scalar)
  r_cpu = torch.ceil(scalar.to("cpu"))
  self.assertEqual(r_mps.cpu(), r_cpu)
```
The second element `1.0` is a contiguous view tensor (similar to slicing), but it has no gather graph created behind. In the placeholder, we won't be able to find the graph, thus relying on the fallback case where we call `_tensor = src.contiguous();`. For an already contiguous tensor, this won't do anything, thus we end up creating the NDArray with all the values of the tensor (`1.2` and `1.0` instead of just `1.0`). Doing `clone` instead of `contiguous` will actually perform a blit behind and take into consideration the `storage_offset` of the view when performing the copy.

Similarly, the following basic case is also failing because of this issue:
```
x = torch.tensor([1.0, 0.49], device="mps")
print(x) # prints 1.0 and 0.0
```