### PR TITLE
Fix mps to cpu casting from a smaller dtype to a bigger dtype

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -823,7 +823,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(
   const int normalized_ndim = normalized_shape.size();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   const int axis = input_ndim - normalized_ndim;
-  at::Tensor input_reshaped = input.view({1, M, -1});
+  at::Tensor input_reshaped = input.reshape({1, M, -1});
   // Unlike Batch Normalization, which applies scalar scale and bias for each
   // entire channel/plane with the affine option, Layer Normalization applies
   // per-element scale and bias. E.g. For input {N, C, H, W}, weight for

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3831,6 +3831,14 @@ class TestNLLLoss(TestCase):
         for shape in [[], (2, 3), (2, 8, 4, 5)]:
             helper(shape)
 
+    def test_cast_mps_to_cpu(self):
+        def helper(src_dtype, dst_dtype):
+            input = torch.rand((1,3,128,128), dtype=src_dtype)
+            input = input.to('mps')
+            input = input.to('cpu', dtype=dst_dtype)
+        helper(torch.half, torch.float)
+        helper(torch.float, torch.half)
+
     # Test adaptive avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now
     def test_adaptive_avg_pool2d_simple(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5066,6 +5066,24 @@ class TestGatherScatter(TestCase):
 
         self.assertEqual(x_cpu, x_mps)
 
+    def test_cast_gather_scatter(self):
+        for _ in range(0, 50):
+            input = np.random.randint(0, 255, size=(5, 5, 4), dtype = np.uint8)
+            with torch.no_grad():
+                s = torch.tensor(input, dtype=torch.uint8, device="mps").unsqueeze(0)
+                s_cpu = torch.tensor(input, dtype=torch.uint8, device="cpu").unsqueeze(0)
+                s = s.long()
+                s_cpu = s_cpu.long()
+                self.assertEqual(s.cpu(), s_cpu)
+
+                s= s.float()
+                s_cpu = s_cpu.float()
+                self.assertEqual(s.cpu(), s_cpu)
+
+                s /= 255
+                s_cpu /= 255
+                self.assertEqual(s.cpu(), s_cpu)
+
     def test_slicing_replace_column(self):
         # https://github.com/pytorch/pytorch/issues/78074
         def _helper(tensor_data):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3834,10 +3834,25 @@ class TestNLLLoss(TestCase):
     def test_cast_mps_to_cpu(self):
         def helper(src_dtype, dst_dtype):
             input = torch.rand((1,3,128,128), dtype=src_dtype)
-            input = input.to('mps')
-            input = input.to('cpu', dtype=dst_dtype)
+            input_cast_mps = input.to('mps')
+            input_cast_cpu = input_cast_mps.to('cpu', dtype=dst_dtype)
+
+            # needs to match the initial Tensor
+            self.assertEqual(input_cast_cpu, input.to(dtype=dst_dtype))
         helper(torch.half, torch.float)
         helper(torch.float, torch.half)
+
+    def test_cast_mps_to_mps(self):
+        def helper(src_dtype, dst_dtype):
+            input_cpu = torch.rand((1,3,128,128), dtype=src_dtype)
+            input_mps = input_cpu.to('mps')
+            output_mps = input_mps.to(dtype=dst_dtype)
+            output_cpu = input_cpu.to(dtype=dst_dtype)
+            self.assertEqual(output_mps.cpu(), output_cpu)
+        helper(torch.half, torch.float)
+        helper(torch.float, torch.half)
+        helper(torch.half, torch.long)
+        helper(torch.float, torch.int)
 
     # Test adaptive avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now


### PR DESCRIPTION
Fixes: 
- https://github.com/pytorch/pytorch/issues/82566
- https://github.com/pytorch/pytorch/issues/80800
- mps->cpu casts from a smaller dtype to a bigger dtype
- mps->mps cast from smaller/bigger dtype to another dtype in case of scatter 

For `mps->cpu` copies where we don't have a source/destination offset, we can save the cast result directly in the destTensor,  so we can skip the additional overhead of the blit. In case we can return the data without doing the blit,  we need to check if it's blocking call, case in which we'd need a `synchronize(SyncType::COMMIT_AND_WAIT);` call (previously this was done by the blit). 