### PR TITLE
Enable adaptive avg pool 2d with larger output size than input size

### DIFF
--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -22,6 +22,8 @@ void set_kernel_params
   TORCH_CHECK((isizeH >= osizeH && isizeW >= osizeW) || (isizeH <= osizeH && isizeW <= osizeW), 
               "Adaptive pool MPS: Input height and width must both be greather than or equal to, or lesser than, output height and width")
 
+  TORCH_CHECK((!(isizeH <= osizeH && isizeW <= osizeW) || (osizeH % isizeH == 0 && osizeW % isizeW == 0)),
+              "Adaptive pool MPS: If output is larger than input, output sizes must be multiples of input sizes")
 
   if(isizeH >= osizeH) {
     strideH = (int64_t) (isizeH / osizeH);

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -19,11 +19,25 @@ void set_kernel_params
    int64_t &strideH, int64_t &strideW,
    int64_t &kernel_sizeH, int64_t &kernel_sizeW) {
 
-  strideH = (int64_t) (isizeH / osizeH);
-  strideW = (int64_t) (isizeW / osizeW);
+  TORCH_CHECK((isizeH >= osizeH && isizeW >= osizeW) || (isizeH < osizeH && isizeW < osizeW), 
+              "Adaptive pool MPS: Input height and width must both be greather than or equal to, or lesser than, output height and width")
 
-  kernel_sizeH = isizeH - (osizeH-1) * strideH;
-  kernel_sizeW = isizeW - (osizeW-1) * strideW;
+
+  if(isizeH >= osizeH) {
+    strideH = (int64_t) (isizeH / osizeH);
+    strideW = (int64_t) (isizeW / osizeW);
+
+    kernel_sizeH = isizeH - (osizeH-1) * strideH;
+    kernel_sizeW = isizeW - (osizeW-1) * strideW;
+  }
+  else {
+    strideH = (int64_t) (osizeH / isizeH);
+    strideW = (int64_t) (osizeW / isizeW);
+
+    kernel_sizeH = osizeH - (isizeH-1) * strideH;
+    kernel_sizeW = osizeW - (isizeW-1) * strideW; 
+  }
+
 }
 
 // Adaptive average pooling
@@ -71,13 +85,29 @@ Tensor& adaptive_avg_pool2d_out_mps
                     strideH, strideW,
                     kernel_sizeH, kernel_sizeW);
 
-  output =  at::avg_pool2d(input,
-                           IntArrayRef({kernel_sizeH, kernel_sizeW}),
-                           IntArrayRef({strideH, strideW}),
-                           IntArrayRef({0, 0}),
-                           false,
-                           true,
-                           c10::nullopt);
+  if(isizeH >= osizeH) {
+    output =  at::avg_pool2d(input,
+                             IntArrayRef({kernel_sizeH, kernel_sizeW}),
+                             IntArrayRef({strideH, strideW}),
+                             IntArrayRef({0, 0}),
+                             false,
+                             true,
+                             c10::nullopt);
+  }
+
+  else {
+    Tensor phony_grad = at::ones_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    phony_grad.resize_(output_size);
+    output =  at::avg_pool2d_backward(input,
+                                      phony_grad;
+                                      IntArrayRef({kernel_sizeH, kernel_sizeW}),
+                                      IntArrayRef({strideH, strideW}),
+                                      IntArrayRef({0, 0}),
+                                      false,
+                                      true,
+                                      c10::nullopt);
+  }
+
   return output;
 }
 
@@ -138,15 +168,23 @@ Tensor adaptive_avg_pool2d_backward_mps
                       strideH, strideW,
                       kernel_sizeH, kernel_sizeW);
     auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-    if (gradInput.numel() != 0)
-      gradInput = at::avg_pool2d_backward(gradOutput,
-                                          input,
-                                          IntArrayRef({kernel_sizeH, kernel_sizeW}),
-                                          IntArrayRef({strideH, strideW}),
-                                          IntArrayRef({0, 0}),
-                                          false,
-                                          true,
-                                          c10::nullopt);
+    if (gradInput.numel() != 0) {
+
+      if(isizeH >= osizeH) {
+        gradInput = at::avg_pool2d_backward(gradOutput,
+                                            input,
+                                            IntArrayRef({kernel_sizeH, kernel_sizeW}),
+                                            IntArrayRef({strideH, strideW}),
+                                            IntArrayRef({0, 0}),
+                                            false,
+                                            true,
+                                            c10::nullopt);
+      }
+      else {
+        // TODO: Need to multiply gradient (result of avgpool2d) with input after computing!
+      }
+
+    }
 
     return gradInput;
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3886,6 +3886,17 @@ class TestNLLLoss(TestCase):
 
         helper((2, 16, 16), (4, 4), False)
 
+        # Output shape larger than input shape
+
+        helper((2, 2, 4, 4), (8, 8), False)
+        helper((2, 2, 2, 2), (4, 4), False)
+        helper((2, 2, 3, 3), (9, 9), False)
+        helper((2, 2, 2, 2), (16, 16), False)
+        helper((2, 2, 2, 16), (16, 16), False)
+
+        helper((2, 4, 4), (16, 16), False)
+
+
     # Test max avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now
     def test_adaptive_max_pool2d_simple(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3896,6 +3896,10 @@ class TestNLLLoss(TestCase):
 
         helper((2, 4, 4), (16, 16), False)
 
+        try:
+            helper((2, 2, 3, 3), (7, 7), False)
+        except Exception as e:
+            pass
 
     # Test max avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now


### PR DESCRIPTION
Fixes #80732

However, the case where output width is smaller than input width, and output height is larger than input height (and vice versa), is not supported.