### PR TITLE
Exclude split float32 from test consistency

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7625,7 +7625,6 @@ class TestConsistency(TestCase):
                               'torch.uint8'],
              'split': ['torch.bool',
                        'torch.float16',
-                       'torch.float32',
                        'torch.int16',
                        'torch.int32',
                        'torch.int64',
@@ -7978,6 +7977,7 @@ class TestConsistency(TestCase):
         'repeat': ['torch.bool'],
         'rot90': ['torch.bool'],
         'tile': ['torch.bool'],
+        'split': ['torch.float32'],
     }
 
     # Used for accept mode only


### PR DESCRIPTION
Fixes #82961 (for now)
