### PR TITLE
Implement as_strided using existing MPSGraph Shape APIs

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -262,7 +262,7 @@ MPSGraphTensor* asStridedLayer_pattern(MPSGraph *graph, MPSGraphTensor *inputTen
       if (dstStrides[dstDim] != 0) {
         int start = dstDimToSliceOffset[dstDim];
         int length = dstDimToSliceLength[dstDim];
-        if (length != [[slicedTensor shape][dstDim] intValue])
+        if (length != [[slicedTensor shape][currDstDim] intValue])
           slicedTensor = [graph sliceTensor:slicedTensor
                                   dimension:currDstDim
                                       start:start

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -37,6 +37,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
   const int64_t storage_offset = needsScatter ? output.storage_offset() : src.storage_offset();
   const MPSDataType inputType  = [cachedGraph->inputTensor dataType];
 
+
   MPSShape *inputShape = [cachedGraph->inputTensor shape];
   MPSShape *outputShape = needsScatter ? inputShape : getMPSShape(src);
 
@@ -77,6 +78,233 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
   }
   return output;
 }
+
+NSDictionary *getStrideToDimLengthOffsetDict(MPSGraphTensor *tensor, NSUInteger rank, NSUInteger offset) {
+  // Assuming input tensor has default strides
+  NSInteger stride = 1;
+  NSMutableDictionary *strideToDimLengthOffset = [[NSMutableDictionary alloc] init];
+  for (NSInteger srcDim = rank - 1; srcDim >= 0; srcDim--) {
+    NSUInteger size = [[tensor shape][srcDim] integerValue];
+    NSDictionary *entry =
+    @{
+      @"dim": [NSNumber numberWithInteger:srcDim],
+      @"length": [tensor shape][srcDim],
+      @"offset": [NSNumber numberWithInteger:offset % size] // offset is determined traversing backwards through stride
+    };
+    [strideToDimLengthOffset setValue:entry forKey:[NSString stringWithFormat:@"%ld",stride]];
+    offset /= size;
+    stride *= size;
+  }
+  return strideToDimLengthOffset;
+}
+
+//#define DEBUG_MPSGRAPH_SHAPE_API_AS_STRIDED
+
+MPSGraphTensor* asStridedLayer_pattern(MPSGraph *graph, MPSGraphTensor *inputTensor, int dstRank, int* dstSizes, int* dstStrides, int offset) {
+#ifdef DEBUG_MPSGRAPH_SHAPE_API_AS_STRIDED
+  printf("input shape:");
+  for (auto length: [inputTensor shape])
+    printf("%lld, ", (int64_t)[length integerValue]);
+  printf("output shape:");
+  for (NSUInteger dstDim = 0; dstDim < dstRank; dstDim++)
+    printf("%lld, ", (int64_t)dstSizes[dstDim]);
+  printf("stride:");
+  for (NSUInteger dstDim = 0; dstDim < dstRank; dstDim++)
+    printf("%lld, ", (int64_t)dstStrides[dstDim]);
+  printf("storage offset: %lld \n", (int64_t)offset);
+#endif
+  if (!dstRank)
+    return nil;
+
+  // Duplicate strides cannot be done
+  {
+    BOOL allUnique = YES;
+    NSMutableSet *uniqueStrides = [[NSMutableSet alloc] init];
+    for (NSInteger dstDim = 0; (dstDim < dstRank) && allUnique; dstDim++) {
+      int stride = dstStrides[dstDim];
+      NSNumber *strideObj = [NSNumber numberWithInt:stride];
+      allUnique &= (stride == 0 || ![uniqueStrides containsObject:strideObj]);
+      [uniqueStrides addObject: strideObj];
+    }
+    [uniqueStrides release];
+    if (!allUnique)
+      return nil;
+  }
+
+  // 1. Flatten the inputTensor if neccessary
+  MPSGraphTensor *flatInputTensor = inputTensor;
+  {
+    // Flatten inputs to remove duplicate strides.
+    BOOL needsFlatten = NO;
+    BOOL allOnes = YES;
+    for(NSUInteger srcDim = 0; srcDim < [[flatInputTensor shape] count]; srcDim++) {
+      needsFlatten |= ([[flatInputTensor shape][srcDim] intValue] == 1);
+      allOnes &= ([[flatInputTensor shape][srcDim] intValue] == 1);
+    }
+    // We have to leave at least 1 dimension, if all input dims are 1
+    if (allOnes) {
+      NSMutableArray *squeezeAxes = [[NSMutableArray alloc] init];
+      for(NSUInteger srcDim = 1; srcDim < [[flatInputTensor shape] count]; srcDim++)
+        [squeezeAxes addObject:[NSNumber numberWithInteger:srcDim]];
+
+      flatInputTensor = [graph squeezeTensor:flatInputTensor
+                                        axes:squeezeAxes
+                                        name:nil];
+      [squeezeAxes release];
+    } else if (needsFlatten) {
+      flatInputTensor = [graph squeezeTensor:flatInputTensor
+                                        name:nil];
+    }
+  }
+
+  int srcRank = (int)[[flatInputTensor shape] count];
+  NSDictionary *srcStrideToDimLengthOffset = getStrideToDimLengthOffsetDict(flatInputTensor, srcRank, offset);
+
+  // Populate the dimension order, slice info, and broadcast info
+  NSMutableArray *dstDimOrder = [[NSMutableArray alloc] init];
+  int *dstDimToSliceLength = (int *) malloc(sizeof(int) * dstRank);
+  int *dstDimToSliceOffset = (int *) malloc(sizeof(int) * dstRank);
+  bool needsBroadcast = false;
+  {
+    for (NSInteger dstDim = dstRank - 1; dstDim >= 0; dstDim--) {
+      if (dstStrides[dstDim] == 0) {
+        // This dimension should be a broadcast
+        needsBroadcast = true;
+        dstDimToSliceLength[dstDim] = dstSizes[dstDim];
+        dstDimToSliceOffset[dstDim] = 0;
+      } else {
+        // Find what dimension and native length was for the specified stride
+        NSDictionary *srcDimLengthOffset = srcStrideToDimLengthOffset[[NSString stringWithFormat:@"%d",dstStrides[dstDim]]];
+
+        // Stride does not exist in source tensor, or the specified size is too long. Not possible
+        // TODO: Longer length with same stride + removal of dim(s) above this is a flatten/reshape. Consider adding support
+        if (!srcDimLengthOffset || dstSizes[dstDim] > [srcDimLengthOffset[@"length"] intValue])
+          return nil;
+
+        // Get the src dimension corresponding to the requested stride
+        NSNumber *srcDim = srcDimLengthOffset[@"dim"];
+        [dstDimOrder insertObject:srcDim atIndex:0];
+
+        dstDimToSliceLength[dstDim] = dstSizes[dstDim];
+        dstDimToSliceOffset[dstDim] = [srcDimLengthOffset[@"offset"] intValue];
+      }
+    }
+  }
+
+  // 2. Slice out any unused dimensions
+  NSMutableArray *missingSrcDims = [[NSMutableArray alloc] init];
+  MPSGraphTensor *slicedUnusedTensor = flatInputTensor;
+  {
+    // Find any src strides/dims that are not present in the dst
+    NSMutableArray *missingSrcStrides = [[NSMutableArray alloc] init];
+    {
+      NSUInteger stride = 1;
+      for (NSInteger srcDim = [[inputTensor shape] count] - 1; srcDim >= 0; srcDim--) {
+        [missingSrcStrides addObject:[NSNumber numberWithInteger:stride]];
+        stride *= [[inputTensor shape][srcDim] integerValue];
+      }
+      for (NSInteger dstDim = 0; dstDim < dstRank; dstDim++) {
+        [missingSrcStrides removeObject:[NSNumber numberWithInteger:dstStrides[dstDim]]];
+      }
+    }
+    for (NSUInteger i = 0; i < [missingSrcStrides count]; i++) {
+      int stride = [missingSrcStrides[i] intValue];
+      NSDictionary *srcDimLengthOffset = srcStrideToDimLengthOffset[[NSString stringWithFormat:@"%d",stride]];
+      NSNumber *missingSrcDim = srcDimLengthOffset[@"dim"];
+      [missingSrcDims addObject:missingSrcDim];
+      [dstDimOrder insertObject:missingSrcDim atIndex:0];
+
+      slicedUnusedTensor = [graph sliceTensor:slicedUnusedTensor
+                                    dimension:[missingSrcDim intValue]
+                                        start:[srcDimLengthOffset[@"offset"] intValue]
+                                       length:1
+                                         name:nil];
+    }
+    [missingSrcStrides release];
+  }
+
+  // 3. Transpose if necessary
+  MPSGraphTensor *transposedTensor = slicedUnusedTensor;
+  {
+    // TODO: Use Transpose API
+    BOOL needsTranspose = NO;
+    for(NSUInteger dstDim = 0; dstDim < [dstDimOrder count] && !needsTranspose; dstDim++ )
+      needsTranspose |= ([dstDimOrder[dstDim] intValue] != dstDim);
+    if (needsTranspose)
+      transposedTensor = [graph transposeTensor:transposedTensor
+                                        permute:dstDimOrder
+                                           name:nil];
+  }
+
+  // 4. Squeeze any unused dimensions following transpose
+  MPSGraphTensor *squeezedTensor = transposedTensor;
+  {
+    // Transpose the missing dims back
+    NSMutableArray *transposedMissingSrcDims = [[NSMutableArray alloc] init];
+    for (NSUInteger dstDim = 0; dstDim < [dstDimOrder count]; dstDim++) {
+      NSNumber *srcDim = dstDimOrder[dstDim];
+      if ([missingSrcDims containsObject:srcDim])
+        [transposedMissingSrcDims addObject:[NSNumber numberWithInt:dstDim]];
+    }
+    if ([transposedMissingSrcDims count])
+      squeezedTensor = [graph squeezeTensor:squeezedTensor
+                                       axes:transposedMissingSrcDims
+                                       name:nil];
+    [transposedMissingSrcDims release];
+  }
+
+  // 5. Slice
+  MPSGraphTensor *slicedTensor = squeezedTensor;
+  {
+    NSUInteger currDstDim = 0;
+    for (NSUInteger dstDim = 0; dstDim < dstRank; dstDim++) {
+      // Only dstDims with nonzero stride are in the current tensor, skip broadcasts
+      if (dstStrides[dstDim] != 0) {
+        int start = dstDimToSliceOffset[dstDim];
+        int length = dstDimToSliceLength[dstDim];
+        if (length != [[slicedTensor shape][dstDim] intValue])
+          slicedTensor = [graph sliceTensor:slicedTensor
+                                  dimension:currDstDim
+                                      start:start
+                                     length:length
+                                       name:nil];
+        currDstDim++;
+      }
+    }
+  }
+
+  // 6. Expand then broadcast the source tensor
+  MPSGraphTensor *broadcastTensor = slicedTensor;
+  if (needsBroadcast) {
+    NSMutableArray *broadcastShape = [[NSMutableArray alloc] init];
+    NSMutableArray *expandAxes = [[NSMutableArray alloc] init];
+    for(NSInteger dstDim = 0; dstDim < dstRank; dstDim++) {
+      [broadcastShape addObject:[NSNumber numberWithInt:dstSizes[dstDim]]];
+      if (dstStrides[dstDim] == 0)
+        [expandAxes addObject:[NSNumber numberWithInt:dstDim]];
+    }
+
+    if ([expandAxes count]) {
+      MPSGraphTensor *expandTensor = [graph expandDimsOfTensor:broadcastTensor
+                                                          axes:expandAxes
+                                                          name:nil];
+      broadcastTensor = [graph broadcastTensor:expandTensor
+                                       toShape:broadcastShape
+                                          name:nil];
+    }
+    [broadcastShape release];
+    [expandAxes release];
+  }
+
+  [srcStrideToDimLengthOffset release];
+  [dstDimOrder release];
+  [missingSrcDims release];
+  free(dstDimToSliceLength);
+  free(dstDimToSliceOffset);
+
+  return broadcastTensor;
+}
+
 
 static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const IntArrayRef& size,
                                           const IntArrayRef& stride, int64_t offset,
@@ -129,6 +357,31 @@ static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const In
       inputTensor = [mpsGraph castTensor:inputTensor
                                   toType:MPSDataTypeInt8
                                     name:@"Cast away from bool"];
+    }
+
+    if (!needsScatter && true) {
+      int *dstSizes = (int *)malloc(shape_size * sizeof(int));
+      int *dstStrides = (int *)malloc(shape_size * sizeof(int));
+      for (NSUInteger dstDim = 0; dstDim < shape_size; dstDim++) {
+        dstSizes[dstDim] = static_cast<int32_t>(size[dstDim]);
+        dstStrides[dstDim] = static_cast<int32_t>(stride[dstDim]);
+      }
+
+      MPSGraphTensor *outputTensor = asStridedLayer_pattern(mpsGraph, inputTensor, shape_size, dstSizes, dstStrides, offset);
+      free(dstSizes);
+      free(dstStrides);
+
+      if (outputTensor) {
+        if (needsBoolCast) {
+          outputTensor = [mpsGraph castTensor:outputTensor
+                                       toType:MPSDataTypeBool
+                                         name:@"Cast back to bool"];
+        }
+        return outputTensor;
+      }
+#ifdef DEBUG_MPSGRAPH_SHAPE_API_AS_STRIDED
+      printf("Failed to implement as strided layer using MPSGraph shape APIs.\n");
+#endif
     }
 
     MPSGraphTensor *reshapedInputTensor = [mpsGraph reshapeTensor: inputTensor


### PR DESCRIPTION
Replace gather side of as_strided mps implementation when possible with MPSGraph shape APIs gives notable perf gain over existing path, roughly equal to the perf gain from using a custom metal kernel. 

Correctness checked by running test_mps.py 