### PR TITLE
Handle output shape for empty input in binary ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -28,10 +28,6 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
                     const Tensor& output_, std::string op_name, BinaryOpBlock binaryBlock)
 {
 
-  // it's possible to receive empty tensors here
-  if (self.numel() == 0 || other.numel() == 0) {
-    return;
-  }
   MPSStream* mpsStream = getCurrentMPSStream();
 
   const bool is_self_scalar = self.dim() == 0;
@@ -40,6 +36,11 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
   auto new_size = at::infer_size(self.sizes(), other.sizes());
   if (!output_.sizes().equals(new_size)) {
       output_.resize_(new_size);
+  }
+
+  // it's possible to receive empty tensors here
+  if (self.numel() == 0 || other.numel() == 0) {
+    return;
   }
 
   Tensor output = output_;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7922,6 +7922,9 @@ class TestConsistency(TestCase):
             'clamp': ['torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
             'clamp_max': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
             'clamp_min': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
+            'logical_and': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
+            'logical_or': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
+            'logical_xor': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
         }
 
     # These ops that are problematic. So never run them even when
@@ -8049,9 +8052,6 @@ class TestConsistency(TestCase):
         'log1p': ['torch.bool', 'torch.int16', 'torch.int32', 'torch.uint8'], 
         'log2': ['torch.bool'], 
         'log': ['torch.bool'], 
-        'logical_and': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
-        'logical_or': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
-        'logical_xor': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
         'logsumexp': ['torch.bool', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'], 
         'matmul': ['torch.uint8'], 
         'mean': ['torch.float16', 'torch.float32'], 


### PR DESCRIPTION
Output of input shape [0,1,2] should be [0,1,2], not [0] i.e. delay returning from empty input condition to resize/reshape the output accordingly