### PR TITLE
Add mps implementation for unique(no dim support) and unique_consecutive

### DIFF
--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -305,11 +305,6 @@ _unique_impl_mps(const Tensor& self, const bool return_inverse, const bool retur
 }
 
 std::tuple<Tensor, Tensor, Tensor>
-unique_dim_mps(const Tensor& self, int64_t dim, const bool sorted, const bool return_inverse, const bool return_counts) {
-  return _unique_impl_mps(self, return_inverse, return_counts, false, c10::make_optional((int64_t)dim));
-}
-
-std::tuple<Tensor, Tensor, Tensor>
 unique_consecutive_mps(const Tensor& self, const bool return_inverse, const bool return_counts, c10::optional<int64_t> dim) {
   return _unique_impl_mps(self, return_inverse, return_counts, true, dim);
 }

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -1,0 +1,311 @@
+//  Copyright © 2022 Apple Inc.
+
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/Resize.h>
+#include <ATen/mps/MPSAllocator.h>
+
+namespace at {
+namespace native {
+namespace mps {
+
+struct UniqueCachedGraph : public MPSCachedGraph
+{
+  UniqueCachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+  MPSGraphTensor* inputTensor_ = nil;
+  MPSGraphTensor* outputTensor_ = nil;
+  MPSGraphTensor* inverseIndicesTensor_ = nil;
+  MPSGraphTensor* countsTensor_ = nil;
+  MPSGraphTensor* lengthTensor_ = nil;
+};
+
+struct UniqueSliceCachedGraph : public MPSCachedGraph
+{
+  UniqueSliceCachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+  MPSGraphTensor* outputTensor_ = nil;
+};
+
+const char * dataTypeToString(MPSDataType dataType)
+{
+    const char * result = nil;
+    switch (dataType)
+    {
+        case MPSDataTypeInvalid: result = "MPSDataTypeInvalid"; break;
+        case MPSDataTypeFloatBit: result = "MPSDataTypeFloatBit"; break;
+        case MPSDataTypeFloat32: result = "MPSDataTypeFloat32"; break;
+        case MPSDataTypeFloat16: result = "MPSDataTypeFloat16"; break;
+        case MPSDataTypeSignedBit: result = "MPSDataTypeSignedBit"; break;
+        case MPSDataTypeInt8: result = "MPSDataTypeInt8"; break;
+        case MPSDataTypeInt16: result = "MPSDataTypeInt16"; break;
+        case MPSDataTypeInt32: result = "MPSDataTypeInt32"; break;
+        case MPSDataTypeInt64: result = "MPSDataTypeInt64"; break;
+        case MPSDataTypeUInt8: result = "MPSDataTypeUInt8"; break;
+        case MPSDataTypeUInt16: result = "MPSDataTypeUInt16"; break;
+        case MPSDataTypeUInt32: result = "MPSDataTypeUInt32"; break;
+        case MPSDataTypeUInt64: result = "MPSDataTypeUInt64"; break;
+        case MPSDataTypeNormalizedBit: result = "MPSDataTypeNormalizedBit"; break;
+        case MPSDataTypeUnorm1: result = "MPSDataTypeUnorm1"; break;
+        case MPSDataTypeUnorm8: result = "MPSDataTypeUnorm8"; break;
+        default: result = "<Unknown datatype>"; break;
+    }
+    return result;
+}
+
+static std::string getUniqueKey(const ScalarType& dtype, const IntArrayRef& base_shape,
+                                const bool return_inverse, const bool return_counts,
+                                const bool consecutive, c10::optional<int64_t> dimOpt)
+{
+  return "_unique2_mps:" + getMPSTypeString(dtype) + "[" + getArrayRefString(base_shape) +
+         "]:[" + (dimOpt.has_value() ? to_string(dimOpt.value()) : "None") + "]:[" + to_string(return_inverse) +
+         "]:[" + to_string(return_counts) + "]:[" + to_string(consecutive) + "]";
+}
+
+NSArray<MPSGraphTensor*> *buildUniqueGraph(UniqueCachedGraph *uniqueGraph, const bool return_inverse, const bool return_counts, const bool consecutive, c10::optional<int64_t> dimOpt) {
+  int64_t dim = dimOpt.has_value() ? dimOpt.value() : 0;
+  
+  MPSGraph *graph = uniqueGraph->graph();
+  MPSGraphTensor *inputTensor = uniqueGraph->inputTensor_;
+  MPSShape *shape = [inputTensor shape];
+  NSUInteger length = [shape[dim] integerValue];
+  MPSDataType dataType = [inputTensor dataType];
+  
+  MPSGraphTensor *resultTensor = nil;
+  MPSGraphTensor *inverseIndicesTensor = nil;
+  MPSGraphTensor *countTensor = nil;
+  MPSGraphTensor *lengthTensor = nil;
+  if (length <= 1) {
+    return @[resultTensor, inverseIndicesTensor, countTensor, lengthTensor];
+  }
+  
+  // Sort only supports following types, cast if necessary
+  if (dataType != MPSDataTypeInt32 &&
+      dataType != MPSDataTypeFloat32 &&
+      dataType != MPSDataTypeFloat16) {
+    dataType = (dataType & MPSDataTypeFloatBit) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
+    inputTensor = [graph castTensor:inputTensor
+                             toType:dataType
+                               name:@"castInputTensor"];
+  }
+
+  if (!dimOpt.has_value())
+    inputTensor = [graph reshapeTensor:inputTensor
+                             withShape:@[@-1]
+                                  name:nil];
+
+  MPSGraphTensor *sortedInput;
+  MPSGraphTensor *argSortedInput;
+  if (consecutive) {
+    sortedInput = inputTensor;
+    argSortedInput = [graph coordinateAlongAxis:dim];
+  } else {
+    sortedInput = [graph sortWithTensor:inputTensor
+                                   axis:dim
+                                   name:nil];
+    argSortedInput = [graph argSortWithTensor:inputTensor
+                                         axis:dim
+                                         name:nil];
+  }
+  
+  MPSGraphTensor *frontNMinusOne = [graph sliceTensor:sortedInput
+                                            dimension:dim
+                                                start:0
+                                               length:length-1
+                                                 name:nil];
+  MPSGraphTensor *backNMinusOne = [graph sliceTensor:sortedInput
+                                           dimension:dim
+                                               start:1
+                                              length:length-1
+                                                name:nil];
+  MPSGraphTensor *notEqualToPreviousElement = [graph notEqualWithPrimaryTensor:backNMinusOne
+                                                               secondaryTensor:frontNMinusOne
+                                                                          name:nil];
+  MPSGraphTensor *castedMask = [graph castTensor:notEqualToPreviousElement
+                                          toType:MPSDataTypeInt32
+                                            name:@"castMaskTensor"];
+  MPSGraphTensor *scannedIndices = [graph cumulativeSumWithTensor:castedMask
+                                                             axis:dim
+                                                             name:nil];
+  lengthTensor = [graph sliceTensor:scannedIndices
+                          dimension:dim
+                              start:length-2
+                             length:1
+                               name:nil];
+  if ([shape count] > 1) {
+      lengthTensor = [graph reductionMaximumWithTensor:lengthTensor
+                                                  axes:nil
+                                                  name:nil];
+  }
+  MPSGraphTensor *minusOneTensor = [graph constantWithScalar:-1.0f
+                                                    dataType:MPSDataTypeInt32];
+  MPSGraphTensor *maskedIndices = [graph selectWithPredicateTensor:notEqualToPreviousElement
+                                               truePredicateTensor:scannedIndices
+                                              falsePredicateTensor:minusOneTensor
+                                                              name:nil];
+  NSMutableArray *headShape = [[NSMutableArray alloc] initWithArray:shape];
+  headShape[dim] = @1;
+  MPSGraphTensor *zeroTensor = [graph constantWithScalar:0.0f
+                                                   shape:headShape
+                                                dataType:MPSDataTypeInt32];
+  [headShape release];
+  MPSGraphTensor *maskedIndicesWithHead = [graph concatTensors:@[zeroTensor, maskedIndices]
+                                                     dimension:dim
+                                                          name:nil];
+  MPSGraphTensor *scannedIndicesWithHead = [graph concatTensors:@[zeroTensor, scannedIndices]
+                                                      dimension:dim
+                                                           name:nil];
+  
+  resultTensor = [graph scatterAlongAxisWithUpdatesTensor:sortedInput
+                                            indicesTensor:maskedIndicesWithHead
+                                                    shape:shape
+                                                     axis:dim
+                                                     mode:MPSGraphScatterModeSet
+                                                     name:nil];
+  
+  inverseIndicesTensor = [graph scatterAlongAxisWithUpdatesTensor:scannedIndicesWithHead
+                                                    indicesTensor:argSortedInput
+                                                            shape:shape
+                                                             axis:dim
+                                                             name:nil];
+
+  MPSGraphTensor *unitTensor = [graph constantWithScalar:1.0f
+                                                   shape:shape
+                                                dataType:MPSDataTypeInt64];
+
+  countTensor = [graph scatterAlongAxisWithUpdatesTensor:unitTensor
+                                           indicesTensor:scannedIndicesWithHead
+                                                   shape:shape
+                                                    axis:dim
+                                                    name:nil];
+  
+  // Cast back if necessary
+  if ([uniqueGraph->inputTensor_ dataType] != dataType)
+    resultTensor = [graph castTensor:resultTensor
+                              toType:[uniqueGraph->inputTensor_ dataType]
+                                name:@"castResultTensor"];
+  
+  return @[resultTensor, inverseIndicesTensor, countTensor, lengthTensor];
+}
+
+static UniqueCachedGraph* getUniqueGraph(const Tensor& self, const bool return_inverse, const bool return_counts, const bool consecutive, c10::optional<int64_t> dim) {
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+
+  @autoreleasepool {
+    string key = getUniqueKey(self.scalar_type(), self.sizes(), return_inverse, return_counts, consecutive, dim);
+    UniqueCachedGraph* cachedGraph = static_cast<UniqueCachedGraph *>(cache_->LookUp(key));
+    if(!cachedGraph) {
+      MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
+
+        UniqueCachedGraph *newCachedGraph = nil;
+
+         @autoreleasepool {
+           // Initialize graph
+           MPSGraph* mpsGraph = make_mps_graph();
+           newCachedGraph = new UniqueCachedGraph(mpsGraph);
+           
+           // Workaround for MPSShaderLibrary bug
+           // TODO: Remove once https://github.com/pytorch/pytorch/issues/82305 is resolved
+           auto inputType = getMPSScalarType(self.scalar_type());
+           if (inputType ==  MPSDataTypeUInt8) {
+               inputType =  MPSDataTypeInt8;
+           }
+           newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, inputType, getMPSShape(self.sizes()));
+
+           NSArray<MPSGraphTensor *> *outputTensors = buildUniqueGraph(newCachedGraph, return_inverse, return_counts, consecutive, dim);
+
+           newCachedGraph->outputTensor_ = outputTensors[0];
+           newCachedGraph->inverseIndicesTensor_ = outputTensors[1];
+           newCachedGraph->countsTensor_ = outputTensors[2];
+           newCachedGraph->lengthTensor_ = outputTensors[3];
+         }
+         return newCachedGraph;
+       });
+       cachedGraph = static_cast<UniqueCachedGraph *>(tmpCachedGraph);
+     }
+    return cachedGraph;
+  }
+}
+
+void runUniqueGraph(UniqueCachedGraph *uniqueGraph, const Tensor& input, Tensor& output,
+                    Tensor& inverse_indices, Tensor& counts, Tensor& length){
+  Placeholder inputPlaceholder = Placeholder(uniqueGraph->inputTensor_, input);
+  Placeholder outputPlaceholder = Placeholder(uniqueGraph->outputTensor_, output);
+  Placeholder inverseIndicesPlaceholder = Placeholder(uniqueGraph->inverseIndicesTensor_, inverse_indices);
+  Placeholder countsPlaceholder = Placeholder(uniqueGraph->countsTensor_, counts);
+  Placeholder lengthPlaceholder = Placeholder(uniqueGraph->lengthTensor_, length);
+
+  NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
+    inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+  };
+
+  NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
+    outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+    inverseIndicesPlaceholder.getMPSGraphTensor() : inverseIndicesPlaceholder.getMPSGraphTensorData(),
+    countsPlaceholder.getMPSGraphTensor() : countsPlaceholder.getMPSGraphTensorData(),
+    lengthPlaceholder.getMPSGraphTensor() : lengthPlaceholder.getMPSGraphTensorData(),
+  };
+
+  // Run the graph
+  MPSStream* stream = getCurrentMPSStream();
+  runMPSGraph(stream, uniqueGraph->graph(), feeds, results);
+}
+
+} // namespace mps
+
+std::tuple<Tensor, Tensor, Tensor>
+_unique_impl_mps(const Tensor& self, const bool return_inverse, const bool return_counts, const bool consecutive, c10::optional<int64_t> dimOpt) {
+  printf("Running mps unique.\n");
+  
+  const Tensor& input = self.contiguous();
+
+  Tensor output = at::native::empty_mps(input.sizes(), input.scalar_type(), c10::nullopt, kMPS);
+  Tensor inverse_indices = at::native::empty_mps(input.sizes(), ScalarType::Long, c10::nullopt, kMPS);
+  Tensor counts = at::native::empty_mps(input.sizes(), ScalarType::Long, c10::nullopt, kMPS);
+  Tensor length = at::native::empty_mps({1}, ScalarType::Int, c10::nullopt, kMPS);
+
+  if (input.numel() == 0)
+    return std::make_tuple(output, inverse_indices, counts);
+
+  mps::UniqueCachedGraph *uniqueGraph = mps::getUniqueGraph(input, return_inverse, return_counts, consecutive, dimOpt);
+//  NSLog(@"%@", [uniqueGraph->graph() debugDescription]);
+
+  mps::runUniqueGraph(uniqueGraph, input, output, inverse_indices, counts, length);
+
+  int64_t lengthScalar = length.item<int64_t>() + 1; // length actually holds max index, add 1
+
+//  printf("length is: %lld\n", lengthScalar);
+  int64_t dim = dimOpt.has_value() ? dimOpt.value() : 0;
+//  printf("dim is: %lld\n", dim);
+
+  output = at::slice(output, dim, 0, lengthScalar);
+  counts = at::slice(counts, dim, 0, lengthScalar);
+  
+  printf("Finished running mps unique.\n");
+
+  return std::make_tuple(output, inverse_indices, counts);
+}
+
+std::tuple<Tensor, Tensor, Tensor>
+unique_dim_mps(const Tensor& self, int64_t dim, const bool sorted, const bool return_inverse, const bool return_counts) {
+  printf("unique_dim\n");
+  return _unique_impl_mps(self, return_inverse, return_counts, false, c10::make_optional((int64_t)dim));
+}
+
+std::tuple<Tensor, Tensor, Tensor>
+unique_consecutive_mps(const Tensor& self, const bool return_inverse, const bool return_counts, c10::optional<int64_t> dim) {
+  printf("unique_consecutive\n");
+  return _unique_impl_mps(self, return_inverse, return_counts, true, dim);
+}
+
+std::tuple<Tensor, Tensor, Tensor>
+unique_dim_consecutive_mps(const Tensor& self, int64_t dim, const bool return_inverse, const bool return_counts) {
+  printf("unique_dim_consecutive\n");
+  return _unique_impl_mps(self, return_inverse, return_counts, true, c10::make_optional((int64_t)dim));
+}
+
+std::tuple<Tensor, Tensor, Tensor>
+_unique2_mps(const Tensor& self, const bool sorted, const bool return_inverse, const bool return_counts) {
+  printf("unique2\n");
+  return _unique_impl_mps(self, return_inverse, return_counts, false, c10::nullopt);
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5509,6 +5509,7 @@
   dispatch:
     CPU: unique_dim_cpu
     CUDA: unique_dim_cuda
+    MPS: unique_dim_mps
   tags: dynamic_output_shape
   autogen: unique_dim.out
 
@@ -5517,6 +5518,7 @@
   dispatch:
     CPU: unique_consecutive_cpu
     CUDA: unique_consecutive_cuda
+    MPS: unique_consecutive_mps
   tags: dynamic_output_shape
   autogen: unique_consecutive.out
 
@@ -5525,6 +5527,7 @@
   dispatch:
     CPU: unique_dim_consecutive_cpu
     CUDA: unique_dim_consecutive_cuda
+    MPS: unique_dim_consecutive_mps
   tags: dynamic_output_shape
   autogen: unique_dim_consecutive.out
 
@@ -5537,6 +5540,7 @@
   dispatch:
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
+    MPS: _unique2_mps
   tags: dynamic_output_shape
   autogen: _unique2.out
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5509,7 +5509,6 @@
   dispatch:
     CPU: unique_dim_cpu
     CUDA: unique_dim_cuda
-    MPS: unique_dim_mps
   tags: dynamic_output_shape
   autogen: unique_dim.out
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_nn import NNTestCase
 import numpy as np
 import torch
 import torch.utils._pytree as pytree
+from itertools import permutations, product
 
 # Same logic as test_cuda.py
 if not torch.backends.mps.is_available():
@@ -1776,6 +1777,109 @@ class TestMPS(TestCase):
         x = torch.tensor([[]], device='mps')
         y = -x
         self.assertEqual(x, y)
+
+    def _test_unique_scalar_empty(self, dtype, device, f):
+        # test scalar
+        x = torch.tensor(0, dtype=dtype, device=device)
+        unique, inverse, counts = f(x, return_inverse=True, return_counts=True)
+        expected_unique = torch.tensor([0], dtype=dtype, device=device)
+        expected_inverse = torch.tensor(0, device=device)
+        expected_counts = torch.tensor([1], device=device)
+        self.assertEqual(unique, expected_unique)
+        self.assertEqual(inverse, expected_inverse)
+        self.assertEqual(counts, expected_counts)
+
+        # test zero sized tensor
+        x = torch.zeros((0, 0, 3), dtype=dtype, device=device)
+        unique, inverse, counts = f(x, return_inverse=True, return_counts=True)
+        expected_unique = torch.tensor([], dtype=dtype, device=device)
+        expected_inverse = torch.empty((0, 0, 3), dtype=torch.long, device=device)
+        expected_counts = torch.tensor([], dtype=torch.long, device=device)
+        self.assertEqual(unique, expected_unique)
+        self.assertEqual(inverse, expected_inverse)
+        self.assertEqual(counts, expected_counts)
+
+    def _test_unique_with_expects(self, device, dtype, f, x, expected_unique, expected_inverse, expected_counts, additional_shape):
+        def ensure_tuple(x):
+            if isinstance(x, torch.Tensor):
+                return (x,)
+            return x
+
+        for return_inverse in [True, False]:
+            for return_counts in [True, False]:
+                # test with expected
+                ret = ensure_tuple(f(x, return_inverse=return_inverse, return_counts=return_counts))
+                self.assertEqual(len(ret), 1 + int(return_inverse) + int(return_counts))
+                self.assertEqual(expected_unique, ret[0])
+                if return_inverse:
+                    self.assertEqual(expected_inverse, ret[1])
+                if return_counts:
+                    count_index = 1 + int(return_inverse)
+                    self.assertEqual(expected_counts, ret[count_index])
+
+                # tests per-element unique on a higher rank tensor.
+                y = x.view(additional_shape)
+                y_unique, y_inverse, y_counts = f(y, return_inverse=True, return_counts=True)
+                self.assertEqual(expected_unique, y_unique)
+                self.assertEqual(expected_inverse.view(additional_shape), y_inverse)
+                self.assertEqual(expected_counts, y_counts)
+
+    def test_unique_all_dtypes(self, device="mps"):
+        def helper(dtype):
+            def ensure_tuple(x):
+                if isinstance(x, torch.Tensor):
+                    return (x,)
+                return x
+
+            if dtype is torch.bool:
+                x = torch.tensor([True, False, False, False, True, False, True, False], dtype=torch.bool, device=device)
+                expected_unique = torch.tensor([False, True], dtype=torch.bool, device=device)
+                expected_inverse = torch.tensor([1, 0, 0, 0, 1, 0, 1, 0], dtype=torch.long, device=device)
+                expected_counts = torch.tensor([5, 3], dtype=torch.long, device=device)
+            else:
+                x = torch.tensor([1, 2, 3, 2, 8, 5, 2, 3], dtype=dtype, device=device)
+                expected_unique = torch.tensor([1, 2, 3, 5, 8], dtype=dtype, device=device)
+                expected_inverse = torch.tensor([0, 1, 2, 1, 4, 3, 1, 2], device=device)
+                expected_counts = torch.tensor([1, 3, 2, 1, 1], device=device)
+
+            # test sorted unique
+            fs = (
+                lambda x, **kwargs: torch.unique(x, sorted=True, **kwargs),
+                lambda x, **kwargs: x.unique(sorted=True, **kwargs),
+            )
+            x_sliced = torch.empty(x.size(0) * 2, dtype=dtype, device=device)[::2].copy_(x)
+            xs = (x, x_sliced)
+            for f, x in product(fs, xs):
+                self._test_unique_with_expects(device, dtype, f, x, expected_unique, expected_inverse, expected_counts, (2, 2, 2))
+                self._test_unique_scalar_empty(dtype, device, f)
+
+            # test unsorted unique
+            fs = (
+                lambda x, **kwargs: torch.unique(x, sorted=False, **kwargs),
+                lambda x, **kwargs: x.unique(sorted=False, **kwargs)
+            )
+            for f, x in product(fs, xs):
+                self._test_unique_scalar_empty(dtype, device, f)
+                for return_inverse, return_counts in product((True, False), repeat=2):
+                    ret = ensure_tuple(f(x, return_inverse=return_inverse, return_counts=return_counts))
+                    self.assertEqual(len(ret), 1 + int(return_inverse) + int(return_counts))
+                    x_list = x.tolist()
+                    x_unique_list = ret[0].tolist()
+                    self.assertEqual(expected_unique.tolist(), sorted(x_unique_list))
+                    if return_inverse:
+                        x_inverse_list = ret[1].tolist()
+                        for i, j in enumerate(x_inverse_list):
+                            self.assertEqual(x_list[i], x_unique_list[j])
+                    if return_counts:
+                        count_index = 1 + int(return_inverse)
+                        x_counts_list = ret[count_index].tolist()
+                        for i, j in zip(x_unique_list, x_counts_list):
+                            count = 0
+                            for k in x_list:
+                                if k == i:
+                                    count += 1
+                            self.assertEqual(j, count)
+        [helper(dtype) for dtype in [torch.float32, torch.float16, torch.int64, torch.int32, torch.int16, torch.uint8]]
 
     def test_unique(self):
         def helper(x, return_inverse, return_counts):
@@ -7851,6 +7955,7 @@ class TestConsistency(TestCase):
         'nonzero': ['f32', 'i16', 'i32', 'i64'],
         'cross': ['f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'linalg.cross': ['f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
+		'unique_consecutive': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         }
 
 
@@ -8073,7 +8178,6 @@ class TestConsistency(TestCase):
         'slice_scatter': [torch.uint8],
         'square': [torch.bool, torch.int16, torch.int32, torch.int64, torch.uint8],  # moved from section below
         'unique': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
-        'unique_consecutive': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'nonzero': [torch.uint8, torch.float16],
 
         # ALLOW_LIST doesn't know about variants

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1776,6 +1776,48 @@ class TestMPS(TestCase):
         x = torch.tensor([[]], device='mps')
         y = -x
         self.assertEqual(x, y)
+        
+    def test_unique(self):
+        def helper(x, return_inverse, return_counts):
+            cpu_x = x
+            x = cpu_x.detach().clone().to('mps')
+
+            result = torch.unique(x, return_inverse=return_inverse, return_counts=return_counts)
+            result_cpu = torch.unique(cpu_x, return_inverse=return_inverse, return_counts=return_counts)
+
+            self.assertEqual(result, result_cpu)
+        helper(torch.tensor([1,2,4,2,1]), False, False)
+        helper(torch.randint(3,(10,)), False, False)
+        helper(torch.randint(3,(10,)), True, False)
+        helper(torch.randint(3,(10,)), False, True)
+        helper(torch.randint(3,(10,)), True, True)
+
+    def test_unique_dim(self):
+        def helper(x, dim, return_inverse, return_counts):
+            cpu_x = x
+            x = cpu_x.detach().clone().to('mps')
+
+            result = torch.unique(x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
+            result_cpu = torch.unique(cpu_x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
+
+            self.assertEqual(result, result_cpu)
+        helper(torch.tensor([1,2,4,2,1]), 0, False, False)
+        helper(torch.randint(3,(10,)), 0, False, False)
+        helper(torch.randint(3,(10,)), 0, True, False)
+        helper(torch.randint(3,(10,)), 0, False, True)
+        helper(torch.randint(3,(10,)), 0, True, True)
+        
+        helper(torch.tensor([[1,2,4,4,1],[4,3,6,5,5]]), 0, False, False)
+        helper(torch.randint(3,(10,10)), 0, False, False)
+        helper(torch.randint(3,(10,10)), 0, True, False)
+        helper(torch.randint(3,(10,10)), 0, False, True)
+        helper(torch.randint(3,(10,10)), 0, True, True)
+        
+        helper(torch.tensor([[1,2,4,4,1],[4,3,6,5,5]]), 1, False, False)
+        helper(torch.randint(3,(10,10)), 1, False, False)
+        helper(torch.randint(3,(10,10)), 1, True, False)
+        helper(torch.randint(3,(10,10)), 1, False, True)
+        helper(torch.randint(3,(10,10)), 1, True, True)
 
     # See https://github.com/pytorch/pytorch/issues/85675
     def test_cat_non_contiguous(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1776,7 +1776,7 @@ class TestMPS(TestCase):
         x = torch.tensor([[]], device='mps')
         y = -x
         self.assertEqual(x, y)
-        
+
     def test_unique(self):
         def helper(x, return_inverse, return_counts):
             cpu_x = x
@@ -1792,13 +1792,13 @@ class TestMPS(TestCase):
         helper(torch.randint(3,(10,)), False, True)
         helper(torch.randint(3,(10,)), True, True)
 
-    def test_unique_dim(self):
+    def test_unique_consecutive(self):
         def helper(x, dim, return_inverse, return_counts):
             cpu_x = x
             x = cpu_x.detach().clone().to('mps')
 
-            result = torch.unique(x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
-            result_cpu = torch.unique(cpu_x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
+            result = torch.unique_consecutive(x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
+            result_cpu = torch.unique_consecutive(cpu_x, dim=dim, return_inverse=return_inverse, return_counts=return_counts)
 
             self.assertEqual(result, result_cpu)
         helper(torch.tensor([1,2,4,2,1]), 0, False, False)
@@ -1806,18 +1806,14 @@ class TestMPS(TestCase):
         helper(torch.randint(3,(10,)), 0, True, False)
         helper(torch.randint(3,(10,)), 0, False, True)
         helper(torch.randint(3,(10,)), 0, True, True)
-        
-        helper(torch.tensor([[1,2,4,4,1],[4,3,6,5,5]]), 0, False, False)
-        helper(torch.randint(3,(10,10)), 0, False, False)
-        helper(torch.randint(3,(10,10)), 0, True, False)
-        helper(torch.randint(3,(10,10)), 0, False, True)
-        helper(torch.randint(3,(10,10)), 0, True, True)
-        
-        helper(torch.tensor([[1,2,4,4,1],[4,3,6,5,5]]), 1, False, False)
-        helper(torch.randint(3,(10,10)), 1, False, False)
-        helper(torch.randint(3,(10,10)), 1, True, False)
-        helper(torch.randint(3,(10,10)), 1, False, True)
-        helper(torch.randint(3,(10,10)), 1, True, True)
+
+        helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 0, False, False)
+        helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 0, True, True)
+        helper(torch.randint(2,(20,2)), 0, True, True)
+
+        helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 1, False, False)
+        helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 1, True, True)
+        helper(torch.randint(2,(2,20)), 1, True, True)
 
     # See https://github.com/pytorch/pytorch/issues/85675
     def test_cat_non_contiguous(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8072,8 +8072,8 @@ class TestConsistency(TestCase):
         'sigmoid': [torch.int64],
         'slice_scatter': [torch.uint8],
         'square': [torch.bool, torch.int16, torch.int32, torch.int64, torch.uint8],  # moved from section below
-
-        # count_nonzero returns wrong results for these dtypes
+        'unique': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
+        'unique_consecutive': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'nonzero': [torch.uint8, torch.float16],
 
         # ALLOW_LIST doesn't know about variants

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1791,6 +1791,8 @@ class TestMPS(TestCase):
         helper(torch.randint(3,(10,)), True, False)
         helper(torch.randint(3,(10,)), False, True)
         helper(torch.randint(3,(10,)), True, True)
+        helper(torch.randint(3,(1,)), True, True)
+        helper(torch.randint(3,(0,)), True, True)
 
     def test_unique_consecutive(self):
         def helper(x, dim, return_inverse, return_counts):
@@ -1806,14 +1808,21 @@ class TestMPS(TestCase):
         helper(torch.randint(3,(10,)), 0, True, False)
         helper(torch.randint(3,(10,)), 0, False, True)
         helper(torch.randint(3,(10,)), 0, True, True)
+        helper(torch.randint(3,(10,)), 0, True, True)
+        helper(torch.randint(3,(1,)), 0, True, True)
+        helper(torch.randint(3,(0,)), 0, True, True)
 
         helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 0, False, False)
         helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 0, True, True)
         helper(torch.randint(2,(20,2)), 0, True, True)
+        helper(torch.randint(2,(1,2)), 0, True, True)
+        helper(torch.randint(2,(0,2)), 0, True, True)
 
         helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 1, False, False)
         helper(torch.tensor([[1,1,2,3,3,2],[1,1,1,2,2,1]]), 1, True, True)
         helper(torch.randint(2,(2,20)), 1, True, True)
+        helper(torch.randint(2,(2,1)), 1, True, True)
+        helper(torch.randint(2,(2,0)), 1, True, True)
 
     # See https://github.com/pytorch/pytorch/issues/85675
     def test_cat_non_contiguous(self):


### PR DESCRIPTION
Adds MPSGraph implementation for unique and unique_consecutive. Currently not possible to support unique with dim argument, as these requires sorting with tensor keys, rather than scalar keys. 