### PR TITLE
Fix base shape size for view ops in case of multiple slices

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -195,7 +195,9 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
     // IntArrayRef wouldn't own the data, so we use a static storage
     static const int64_t shape_1d = 1;
     // self.sizes().size() could be zero
-    base_shape = self.sizes().size() ? self.sizes() : IntArrayRef(&shape_1d, 1);
+    base_shape = self.sizes().size() ? self.sizes() :
+                      self.is_view() ? self._base().sizes() : IntArrayRef(&shape_1d, 1);
+
     // base_shape will be retained in MPSAllocator until buffer gets recycled
     if (self.storage().data())
       set_buffer_shape(self.storage().data(), base_shape);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1352,6 +1352,18 @@ class TestMPS(TestCase):
         for op in ["<=", "<", ">=", ">", "==", "!="]:
             helper(op)
 
+    def test_slice_of_slice(self):
+        x = torch.tensor([0.5, 0.5], device="cpu")
+        x_mps = torch.tensor([0.5, 0.5], device="mps")
+
+        tensor = x[1][None]
+        tensor_mps = x_mps[1][None]
+
+        res = tensor.ne(0)
+        res_mps = tensor_mps.ne(0)
+
+        torch.testing.assert_close(res, res_mps.cpu())
+
     def test_index_storage_offset(self):
         # https://github.com/pytorch/pytorch/issues/78107
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1362,7 +1362,7 @@ class TestMPS(TestCase):
         res = tensor.ne(0)
         res_mps = tensor_mps.ne(0)
 
-        torch.testing.assert_close(res, res_mps.cpu())
+        self.assertEqual(res, res_mps)
 
     def test_index_storage_offset(self):
         # https://github.com/pytorch/pytorch/issues/78107


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/84364, https://github.com/pytorch/pytorch/issues/85592

Fixes bug for view ops where the base shape would be incorectly determined.
E.g for the following tensor `torch.tensor([0.5, 0.5], device="mps")[1][None]`, we could consider the base shape of the parent tensor as 1, while the actual base shape is 2.