### PR TITLE
Handle compatible inputs to where

### DIFF
--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -392,20 +392,22 @@ Tensor where_mps(const Tensor& condition,
 
   auto max_dim = std::max(condition.dim(), std::max(self.dim(), other.dim()));
 
-  auto sum_dims = condition.dim() + self.dim() + other.dim();
-
-  TORCH_CHECK(max_dim == 0 || !(sum_dims % max_dim), "All inputs of where should have same/compatible number of dims")
-
   int64_t out_arr[max_dim];
 
   // Broadcasted output shape
   for(int i = 0; i < max_dim; i++) {
 
-    int64_t cond_num = cond_zero_shape ? 0 : condition.size(i);
-    int64_t self_num = self_zero_shape ? 0 : self.size(i);
-    int64_t other_num = other_zero_shape ? 0 : other.size(i);
+    int64_t cond_idx = cond_zero_shape ? 1 : (i < condition.dim() ? condition.size(i) : 1);
+    int64_t self_idx = self_zero_shape ? 1 : (i < self.dim() ? self.size(i) : 1);
+    int64_t other_idx = other_zero_shape ? 1 : (i < other.dim() ? other.size(i) : 1);
 
-    out_arr[i] = std::max(cond_num, std::max(self_num, other_num));
+    auto max_idx = std::max(cond_idx, std::max(self_idx, other_idx));
+
+    TORCH_CHECK(cond_idx == max_idx || cond_idx == 1, i, "'th index ", cond_idx, " of condition tensor does not match the other tensors")
+    TORCH_CHECK(self_idx == max_idx || self_idx == 1, i, "'th index ", self_idx, " of x tensor does not match the other tensors")
+    TORCH_CHECK(other_idx == max_idx || other_idx == 1, i, "'th index ", other_idx, " of x tensor does not match the other tensors")
+
+    out_arr[i] = max_idx;
   }
 
   Tensor ret = empty_mps(IntArrayRef(out_arr, max_dim),

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -401,7 +401,7 @@ Tensor where_mps(const Tensor& condition,
     int64_t self_idx = self_zero_shape ? 1 : (i < self.dim() ? self.size(i) : 1);
     int64_t other_idx = other_zero_shape ? 1 : (i < other.dim() ? other.size(i) : 1);
 
-    auto max_idx = std::max(cond_idx, std::max(self_idx, other_idx));
+    auto max_idx = std::max({cond_idx, self_idx, other_idx});
 
     TORCH_CHECK(cond_idx == max_idx || cond_idx == 1, i, "'th index ", cond_idx, " of condition tensor does not match the other tensors")
     TORCH_CHECK(self_idx == max_idx || self_idx == 1, i, "'th index ", self_idx, " of x tensor does not match the other tensors")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8010,7 +8010,7 @@ class TestConsistency(TestCase):
             'logical_xor': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'],
             'native_layer_norm': ['torch.float32'],
             'nn.functional.layer_norm': ['torch.float32'],
-            'where': ['torch.bool','torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'],
+            'where': ['torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'],
         }
 
     # These ops that are problematic. So never run them even when
@@ -8019,7 +8019,7 @@ class TestConsistency(TestCase):
     # All the entries in this list should be removed
     BLOCKLIST = {
         # Functions that hang
-        'masked_fill': [torch.bool, torch.uint8, torch.float32],
+        'masked_fill': [torch.bool, torch.uint8, torch.float32], 'where': [torch.bool],
         # Functions that hard crash
         'nn.functional.kl_div': [torch.int16, torch.int32, torch.int64],
         'nn.functional.nll_loss': [torch.float32],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8010,6 +8010,7 @@ class TestConsistency(TestCase):
             'logical_xor': ['torch.bool', 'torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'],
             'native_layer_norm': ['torch.float32'],
             'nn.functional.layer_norm': ['torch.float32'],
+            'where': ['torch.bool','torch.float16', 'torch.float32', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.uint8'],
         }
 
     # These ops that are problematic. So never run them even when
@@ -8018,7 +8019,7 @@ class TestConsistency(TestCase):
     # All the entries in this list should be removed
     BLOCKLIST = {
         # Functions that hang
-        'masked_fill': [torch.bool, torch.uint8, torch.float32], 'where': [torch.bool],
+        'masked_fill': [torch.bool, torch.uint8, torch.float32],
         # Functions that hard crash
         'nn.functional.kl_div': [torch.int16, torch.int32, torch.int64],
         'nn.functional.nll_loss': [torch.float32],


### PR DESCRIPTION
Inputs with different number of dimensions but compatible shapes were being rejected

e.g. x.shape = [10,1,10]
       y.shape = [10,10]
      cond.shape = [10,10,1]