### PR TITLE
Add MPSHooks interface to enable accessing specific MPS functions globally

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -21,10 +21,6 @@
 #include <fbgemm/Fbgemm.h>
 #endif // USE_FBGEMM
 
-#ifdef USE_MPS
-#include <ATen/mps/MPSDevice.h>
-#endif
-
 namespace at {
 
 Context::Context() = default;
@@ -231,14 +227,6 @@ bool Context::hasMKL() {
 bool Context::hasMKLDNN() {
 #if AT_MKLDNN_ENABLED()
   return true;
-#else
-  return false;
-#endif
-}
-
-bool Context::hasMPS() {
-#if USE_MPS
-  return at::mps::is_available();
 #else
   return false;
 #endif

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -9,6 +9,7 @@
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
 #include <ATen/detail/ORTHooksInterface.h>
+#include <ATen/detail/MPSHooksInterface.h>
 #include <c10/core/QEngine.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/CallOnce.h>
@@ -83,6 +84,9 @@ class TORCH_API Context {
   static bool hasHIP() {
     return detail::getHIPHooks().hasHIP();
   }
+  static bool hasMPS() {
+    return detail::getMPSHooks().hasMPS();
+  }
   static bool hasIPU() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::IPU);
   }
@@ -92,8 +96,6 @@ class TORCH_API Context {
   static bool hasLazy() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::Lazy);
   }
-  static bool hasMPS();
-
   static bool hasORT() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::ORT);
   }

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -1,0 +1,32 @@
+#include <ATen/detail/MPSHooksInterface.h>
+#include <c10/util/Exception.h>
+
+namespace at {
+namespace detail {
+
+const MPSHooksInterface& getMPSHooks() {
+  static std::unique_ptr<MPSHooksInterface> mps_hooks;
+#if !defined C10_MOBILE
+  static std::once_flag once;
+  std::call_once(once, [] {
+    mps_hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
+    if (!mps_hooks) {
+      mps_hooks =
+          // NOLINTNEXTLINE(modernize-make-unique)
+          std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+    }
+  });
+#else
+  if (mps_hooks == nullptr) {
+    mps_hooks =
+        // NOLINTNEXTLINE(modernize-make-unique)
+        std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+  }
+#endif
+  return *mps_hooks;
+}
+} // namespace detail
+
+C10_DEFINE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs)
+
+} // namespace at

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <c10/core/Allocator.h>
+#include <ATen/core/Generator.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Registry.h>
+
+#include <cstddef>
+#include <functional>
+
+namespace at {
+class Context;
+}
+
+namespace at {
+
+struct TORCH_API MPSHooksInterface {
+  virtual ~MPSHooksInterface() {}
+
+  // Initialize the MPS library state
+  virtual void initMPS() const {
+    AT_ERROR("Cannot initialize MPS without MPS backend.");
+  }
+
+  virtual bool hasMPS() const {
+    return false;
+  }
+
+  virtual const Generator& getDefaultMPSGenerator(DeviceIndex device_index = -1) const {
+    (void)device_index; // Suppress unused variable warning
+    AT_ERROR("Cannot get default MPS generator without MPS backend.");
+  }
+
+  virtual Allocator* getMPSDeviceAllocator() const {
+    AT_ERROR("MPSDeviceAllocator requires MPS.");
+  }
+};
+
+struct TORCH_API MPSHooksArgs {};
+
+C10_DECLARE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs);
+#define REGISTER_MPS_HOOKS(clsname) \
+  C10_REGISTER_CLASS(MPSHooksRegistry, clsname, clsname)
+
+namespace detail {
+TORCH_API const MPSHooksInterface& getMPSHooks();
+
+} // namespace detail
+} // namespace at

--- a/aten/src/ATen/mps/MPSHooks.cpp
+++ b/aten/src/ATen/mps/MPSHooks.cpp
@@ -1,0 +1,35 @@
+#include <ATen/mps/MPSHooks.h>
+
+#include <ATen/Context.h>
+#include <ATen/mps/MPSDevice.h>
+#include <ATen/detail/MPSHooksInterface.h>
+#include <c10/util/irange.h>
+
+#include <sstream>
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace at {
+namespace mps {
+
+void MPSHooks::initMPS() const {
+  C10_LOG_API_USAGE_ONCE("aten.init.mps");
+  // TODO: initialize MPS devices and streams here
+}
+
+bool MPSHooks::hasMPS() const {
+  return at::mps::is_available();
+}
+
+Allocator* MPSHooks::getMPSDeviceAllocator() const {
+  return at::mps::GetMPSAllocator();
+}
+
+using at::MPSHooksRegistry;
+using at::RegistererMPSHooksRegistry;
+
+REGISTER_MPS_HOOKS(MPSHooks);
+
+} // namespace mps
+} // namespace at

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ATen/detail/MPSHooksInterface.h>
+#include <ATen/Generator.h>
+#include <c10/util/Optional.h>
+
+namespace at { namespace mps {
+
+// The real implementation of MPSHooksInterface
+struct MPSHooks : public at::MPSHooksInterface {
+  MPSHooks(at::MPSHooksArgs) {}
+  void initMPS() const override;
+  bool hasMPS() const override;
+  Allocator* getMPSDeviceAllocator() const override;
+};
+
+}} // at::mps


### PR DESCRIPTION
The MPS hooks interface is required for the up coming changes to add MPSGenerator for Random Ops, and manual seeding.