### PR TITLE
Fix empty dispatch for bitwise_not

### DIFF
--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -310,6 +310,10 @@ at::Tensor& bitwise_not_out_mps (const at::Tensor& self, at::Tensor& output_) {
                                                      getMetalType(self),
                                                      "bitwise_not");
   uint32_t length = output.numel();
+  if (length == 0) {
+    return output_;
+  }
+
   dispatch_sync(stream->queue(), ^(){
     id<MTLCommandBuffer> buffer = stream->commandBuffer();
     id<MTLComputeCommandEncoder> commandEncoder = [buffer computeCommandEncoder];


### PR DESCRIPTION
Fixes bitwise_not crash on AMD for empty dispatches:
```
test_output_match_bitwise_not_cpu_int16 (__main__.TestConsistencyCPU) ... zsh: floating point exception  python3 test_mps.py --verbose -k test_output_match_bitwise_not_cpu_int16
```
