### PR TITLE
Fix the base shape of view tensor in as_strided_mps

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -237,10 +237,10 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
 
   // If dst is contiguous and there is no byte offset, we can save directly the result of
   // gather into dst. This reduces the overhead of doing an additional blit for most cases
-  bool returnGatherOutput = (dst_.is_contiguous() && !dst_byte_offset);
+  bool returnGatherOutput = (dst_.is_contiguous() && !dst_byte_offset && src_.dtype() == dst_.dtype());
   Tensor src;
 
-  if (!src_.is_contiguous()) {
+  if (src_.is_view() || !src_.is_contiguous()) {
     Tensor emptyShell = Tensor();
     src = gatherViewTensor(src_, returnGatherOutput ? dst_ : emptyShell);
 


### PR DESCRIPTION
- Fix the type mismatch bug if returning early from copy_kernel_mps when copy_cast is needed
- Create the view graph in gatherViewTensor instead of as_strided
- Fix the crash in asStridedLayer_reshapePattern() caused by negative srcDim