### PR TITLE
Add suport for casting updatesTensor to match outputTensor dtype directly in scatter

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -260,18 +260,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   // If the memory is not contiguous, it means that the tensor has strides and we would not be
   // able to do the copy using a single blit
   if (!dst_.is_contiguous()) {
-    Tensor tmp;
-    if (src.dtype() != dst_.dtype()) {
-      id<MTLBuffer> tmpBuffer = sourceBuffer;
-      if (src.element_size() < dst_.element_size()) {
-        tmp = at::native::empty_mps(dst_.sizes(), dst_.scalar_type(), c10::nullopt, kMPS);
-        tmpBuffer = getMTLBufferStorage(tmp);
-      }
-
-      copy_cast_mps(dst_, src, tmpBuffer, sourceBuffer);
-    }
-
-    return scatterViewTensor((src.dtype() != dst_.dtype() && tmp.has_storage()) ? tmp : src, dst_);
+    return scatterViewTensor(src, dst_);
   }
   src._set_conj(src_.is_conj());
   src._set_neg(src_.is_neg());

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -18,11 +18,16 @@ struct ViewCachedGraph : public MPSCachedGraph
   std::vector<MPSGraphTensor*> strideTensors;
 };
 
-static std::string getStridedKey(const ScalarType& dtype, const IntArrayRef& base_shape,
+static std::string getStridedKey(const ScalarType& dtype, const ScalarType& updates_dtype, const IntArrayRef& base_shape,
                                  const IntArrayRef& new_shape, const IntArrayRef& stride,
                                  int64_t storage_offset, bool is_scatter)
 {
-  return (is_scatter ? "scatter:" : "gather:") + getMPSTypeString(dtype) + "[" +
+  std::string dtype_key = getMPSTypeString(dtype);
+  if (is_scatter) {
+    dtype_key += ":" + getMPSTypeString(updates_dtype);
+  }
+
+  return (is_scatter ? "scatter:" : "gather:") + dtype_key + "[" +
          getArrayRefString(base_shape) + "]:[" + getArrayRefString(new_shape) + "]:[" +
          getArrayRefString(stride) + "]:[" + to_string(storage_offset) + "]";
 }
@@ -51,7 +56,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
     if (needsScatter) {
       feeds[cachedGraph->updatesTensor] = [[[MPSGraphTensorData alloc] initWithMTLBuffer: sourceBuffer
                                                                                    shape: getMPSShape(src.numel())
-                                                                                dataType: inputType] autorelease];
+                                                                                dataType: getMPSDataType(src.scalar_type())] autorelease];
     }
     MPSScalar storageOffsetScalar = getMPSScalar(storage_offset, ScalarType::Int);
     feeds[cachedGraph->storageOffsetTensor] = getMPSGraphTensorFromScalar(stream, storageOffsetScalar);
@@ -411,7 +416,8 @@ MPSGraphTensor* asStridedLayer_pattern(MPSGraph *graph, MPSGraphTensor *inputTen
 static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const IntArrayRef& size,
                                           const IntArrayRef& stride, int64_t offset,
                                           const IntArrayRef& base_shape, bool needsScatter,
-                                          const bool needsBoolCast)
+                                          const bool needsBoolCast,
+                                          MPSGraphTensor* updatesTensor)
 {
   MPSGraph* mpsGraph = cachedGraph->graph();
   MPSGraphTensor *outputTensor = nil;
@@ -483,7 +489,7 @@ static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const In
     if (needsScatter) {
       MPSGraphTensor* scatteredTensor = [mpsGraph scatterAlongAxis: (NSInteger) 0
                                                     withDataTensor: reshapedInputTensor
-                                                     updatesTensor: cachedGraph->updatesTensor
+                                                     updatesTensor: updatesTensor
                                                      indicesTensor: reshapedIndicesTensor
                                                               mode: MPSGraphScatterModeSet
                                                               name: nil];
@@ -549,12 +555,12 @@ static IntArrayRef updateTensorBaseShape(const Tensor& self)
 //            |    /          \   |
 //            |   /            \  |
 //            NonView T         NonView T
-static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, IntArrayRef stride, int64_t storage_offset, bool needsScatter)
+static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, IntArrayRef stride, int64_t storage_offset, bool needsScatter, const Tensor &other)
 {
   IntArrayRef base_shape = updateTensorBaseShape(self);
 
   @autoreleasepool {
-    string key = getStridedKey(self.scalar_type(), base_shape, size, stride, storage_offset, needsScatter);
+    string key = getStridedKey(self.scalar_type(), other.scalar_type(), base_shape, size, stride, storage_offset, needsScatter);
     MPSGraphCache* cache_ = MPSGraphCache::getInstance();
     ViewCachedGraph* cachedGraph = static_cast<ViewCachedGraph *>(cache_->LookUp(key));
 
@@ -563,6 +569,7 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
         ViewCachedGraph *newCachedGraph = nil;
         @autoreleasepool {
             MPSGraph* mpsGraph = make_mps_graph();
+            MPSGraphTensor* updatesTensor = nil;
             newCachedGraph = new ViewCachedGraph(mpsGraph);
             // Workaround for MPSShaderLibrary bug
             // TODO: Remove once https://github.com/pytorch/pytorch/issues/82305 is resolved
@@ -578,9 +585,16 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
               newCachedGraph->strideTensors.push_back(mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[@1]));
             }
             if (needsScatter) {
-              newCachedGraph->updatesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, inputType);
+              auto updatesType = getMPSScalarType(other.scalar_type());
+              newCachedGraph->updatesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, updatesType);
+              updatesTensor = newCachedGraph->updatesTensor;
+              if (inputType != updatesType) {
+                updatesTensor = [mpsGraph castTensor:updatesTensor
+                                              toType:inputType
+                                                name:@"castUpdatesTensor"];
+              }
             }
-            newCachedGraph->outputTensor = chainViewOperation(newCachedGraph, size, stride, storage_offset, base_shape, needsScatter, needsBoolCast);
+            newCachedGraph->outputTensor = chainViewOperation(newCachedGraph, size, stride, storage_offset, base_shape, needsScatter, needsBoolCast, updatesTensor);
         }
         return newCachedGraph;
       }));
@@ -599,14 +613,14 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst)
     output = at::native::empty_mps(src.sizes(), src.scalar_type(), c10::nullopt, kMPS);
   }
   ViewCachedGraph* cachedGraph = createViewGraph(src, src.sizes(), src.strides(),
-                                                 src.storage_offset(), /*needsScatter*/ false);
+                                                 src.storage_offset(), /*needsScatter*/ false, dst);
   return runViewGraph(cachedGraph, src, dst.has_storage() ? dst : output, /*needsScatter*/ false);
 }
 
 Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output)
 {
   ViewCachedGraph* cachedGraph = createViewGraph(output, output.sizes(), output.strides(),
-                                                 output.storage_offset(), /*needsScatter*/ true);
+                                                 output.storage_offset(), /*needsScatter*/ true, src);
   return runViewGraph(cachedGraph, src, output, /*needsScatter*/ true);
 }
 


### PR DESCRIPTION
Fixes copies into slices where the input data type is different than the output dtype.

This change removes the cast done before scatter, so we don't have to allocate additional memory to perform the casting. Scatter handles the casting directly now.

```
device = "mps"
shape = (4, 4)
tensor = torch.randint(10, shape, device=device)
tensor_before = tensor.clone()
res = torch.empty(shape[0], shape[1] * 2, device=device)[:, ::2].copy_(tensor)
torch.testing.assert_close(tensor, tensor_before)
```
