### PR TITLE
Fix multinomial crash for negative values in bandOP

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -395,9 +395,13 @@ Tensor& multinomial_with_replacement_mps_kernel(
           MPSGraphTensor *ones = [mpsGraph constantWithScalar:1.0f
                                                         shape:@[ns_numCategories, ns_numCategories]
                                                      dataType:prob_dtype];
+          MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0f
+                                                          dataType:MPSDataTypeInt32];
+          MPSGraphTensor *minusOneTensor = [mpsGraph constantWithScalar:-1.0f
+                                                              dataType:MPSDataTypeInt32];
           MPSGraphTensor *upperTriangle = [mpsGraph bandPartWithTensor:ones
-                                                              numLower:0
-                                                              numUpper:-1
+                                                        numLowerTensor:zeroTensor
+                                                        numUpperTensor:minusOneTensor
                                                                   name:nil];
           MPSGraphTensor *upperProbRange = [mpsGraph matrixMultiplicationWithPrimaryTensor:normalizedProbs
                                                                            secondaryTensor:upperTriangle


### PR DESCRIPTION
Fixes multinomial crash happening on AMD:

```
test_multinomial (__main__.TestNLLLoss) ... 2022-10-21 10:55:57.184 python3[96212:646664] Error getting visible function:
 (null) error: invalid qualified function name 'bandPartOp_0_m-2147483648__f'
/AppleInternal/Library/BuildRoots/4883e71d-37bd-11ed-b0ef-b25c5e9b9057/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShaders/MPSCore/Utility/MPSKernelDAG.mm:785: failed assertion `Error getting visible function:
 (null) error: invalid qualified function name 'bandPartOp_0_m-2147483648__f'
```