### PR TITLE
Solve contiguos view tensors using arrayViews instead of blits

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -49,6 +49,7 @@ std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
 Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output, id<MTLBuffer> updatesBuffer = nil);
+MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mpsShape, const MPSDataType mpsDataType);
 
 MPSShape* getMPSShape(const Tensor& t);
 MPSShape* getMPSShape(IntArrayRef sizes);
@@ -87,6 +88,7 @@ MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar&
 
 MPSGraph* make_mps_graph();
 void printTensorNDArray(const Tensor& t);
+MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType mpsType);
 
 MPSGraphTensor* mpsGraphUnrankedPlaceHolder(MPSGraph *mpsGraph, MPSDataType dataType);
 MPSGraphTensor* mpsGraphRankedPlaceHolder(MPSGraph *mpsGraph, MPSDataType dataType, MPSShape* mpsShape);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -172,7 +172,7 @@ MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType
   id<MTLBuffer> buffer = getMTLBufferStorage(tensor);
   MPSGraphTensorData* tmpGraphTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buffer
                                                                                     shape:shape
-                                                                                  dataType:mpsType] autorelease];
+                                                                                 dataType:mpsType] autorelease];
 
   return [tmpGraphTensorData mpsndarray];
 }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -166,7 +166,6 @@ void printTensorNDArray(const Tensor& t) {
   C10_CLANG_DIAGNOSTIC_POP()
 }
 
-static
 MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType mpsType)
 {
   id<MTLBuffer> buffer = getMTLBufferStorage(tensor);
@@ -175,97 +174,6 @@ MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType
                                                                                  dataType:mpsType] autorelease];
 
   return [tmpGraphTensorData mpsndarray];
-}
-
-static
-MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mpsShape, const MPSDataType mpsDataType) {
-  IntArrayRef src_base_shape = get_buffer_shape(src.storage().data());
-  std::vector<int64_t> src_view_shape;
-  bool hasMPSShape = (mpsShape != nil);
-  int src_ndim_base = src_base_shape.size();
-  int src_ndim_view = 0;
-  if (hasMPSShape) {
-    src_ndim_view = [mpsShape count];
-    src_view_shape.reserve(src_ndim_view);
-    for (const auto i : c10::irange(src_ndim_view)) {
-      src_view_shape[i] = [mpsShape[i] intValue];
-    }
-  } else {
-    src_ndim_view = src.dim();
-    src_view_shape = src.sizes().vec();
-  }
-
-  MPSNDArray *srcTensorNDArrayView = nil;
-  MPSNDArrayDescriptor *srcTensorNDArrayDesc = nil;
-  MPSNDArray *srcTensorNDArray = nil;
-  id<MTLCommandBuffer> commandBuffer = getCurrentMPSStream()->commandBuffer();
-
-  if (src_ndim_base == src_ndim_view) {
-    srcTensorNDArray = ndArrayFromTensor(src, getMPSShape(src_base_shape), mpsDataType);
-    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
-
-    int firstDimToSlice = 0;
-    while (src_base_shape[firstDimToSlice] == src_view_shape[firstDimToSlice]) {
-      firstDimToSlice++;
-    }
-
-    int view_numel = 1;
-    for (const auto i : c10::irange(firstDimToSlice + 1, src_base_shape.size())) {
-      view_numel *= src_base_shape[i];
-    }
-
-    int sliceOffset = src.storage_offset() / view_numel;
-    // There are cases where both dimensions of a view can shrink
-    // E.g: x = torch.randn((3,6))[1, 1:3]
-    int nextSliceOffset = src.storage_offset() % view_numel;
-
-    [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), src.sizes()[firstDimToSlice]}];
-    if (nextSliceOffset) {
-      [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 2 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(nextSliceOffset), src.sizes()[firstDimToSlice+1]}];
-    }
-  }
-  else {
-    int src_view_numel = 1;
-    for (const auto i : c10::irange(src_ndim_view)) {
-      src_view_numel *= src_view_shape[i];
-    }
-
-    int idx = 0;
-    int finalShapeSize = (src_ndim_view == 0) ? 1 : src_ndim_view;
-    std::vector<NSNumber*> mpsFinalShape(finalShapeSize);
-
-    // When the shapes are different, we need to flatten the first slice in order to alias the memory without any copies
-    // E.g: base tensor [5, 7, 3], view tensor [7, 3] (storage_offset=21). We need to flatten [5, 7, 3] to [35, 3], then
-    // we can slice directly into the first dimension based on the storage_offset
-    uint32_t flattenedSlice = 1;
-    for (const auto i : c10::irange(src_ndim_base - finalShapeSize + 1)) {
-      flattenedSlice *= src_base_shape[i];
-    }
-    mpsFinalShape[idx++] = [NSNumber numberWithInteger:flattenedSlice];
-
-    for (const auto i : c10::irange(src_ndim_base - finalShapeSize + 1, src_ndim_base)) {
-      mpsFinalShape[idx++] = [NSNumber numberWithInteger:src_base_shape[i]];
-    }
-
-    mpsShape = [NSArray arrayWithObjects:mpsFinalShape.data() count:mpsFinalShape.size()];
-    srcTensorNDArray = ndArrayFromTensor(src, mpsShape, mpsDataType);
-    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
-
-    int dim0 = (src_ndim_view == 0) ? 1 : src_view_shape[0];
-    int totalSlices = dim0;
-
-    // For 1D arrays, the storage_offset gives directly the
-    // starting point from where the slice should start
-    int sliceOffset = src_ndim_view == 1 ? 1 : dim0;
-    int view_numel = src_ndim_view == 1 ? 1 : src_view_numel;
-    [srcTensorNDArrayDesc sliceDimension:finalShapeSize - 1 withSubrange:{static_cast<NSUInteger>((src.storage_offset() / view_numel) * sliceOffset), totalSlices}];
-  }
-
-  srcTensorNDArrayView = [srcTensorNDArray arrayViewWithCommandBuffer:commandBuffer
-                                                           descriptor:srcTensorNDArrayDesc
-                                                             aliasing:MPSAliasingStrategyShallAlias];
-
-  return [[[MPSGraphTensorData alloc] initWithMPSNDArray:srcTensorNDArrayView] autorelease];
 }
 
 Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSShape *mpsShape, bool gatherTensorData) : _tensor(src)

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -166,13 +166,115 @@ void printTensorNDArray(const Tensor& t) {
   C10_CLANG_DIAGNOSTIC_POP()
 }
 
+static
+MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType mpsType)
+{
+  id<MTLBuffer> buffer = getMTLBufferStorage(tensor);
+  MPSGraphTensorData* tmpGraphTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buffer
+                                                                                    shape:shape
+                                                                                  dataType:mpsType] autorelease];
+
+  return [tmpGraphTensorData mpsndarray];
+}
+
+static
+MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mpsShape, const MPSDataType mpsDataType) {
+  IntArrayRef src_base_shape = get_buffer_shape(src.storage().data());
+  std::vector<int64_t> src_view_shape;
+  bool hasMPSShape = (mpsShape != nil);
+  int src_ndim_base = src_base_shape.size();
+  int src_ndim_view = 0;
+  if (hasMPSShape) {
+    src_ndim_view = [mpsShape count];
+    src_view_shape.reserve(src_ndim_view);
+    for (int i = 0; i < src_ndim_view; i++) {
+      src_view_shape[i] = [mpsShape[i] intValue];
+    }
+  } else {
+    src_ndim_view = src.dim();
+    src_view_shape = src.sizes().vec();
+  }
+
+  MPSNDArray *srcTensorNDArrayView = nil;
+  MPSNDArrayDescriptor *srcTensorNDArrayDesc = nil;
+  MPSNDArray *srcTensorNDArray = nil;
+  id<MTLCommandBuffer> commandBuffer = getCurrentMPSStream()->commandBuffer();
+
+  if (src_ndim_base == src_ndim_view) {
+    srcTensorNDArray = ndArrayFromTensor(src, getMPSShape(src_base_shape), mpsDataType);
+    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
+
+    int firstDimToSlice = 0;
+    while (src_base_shape[firstDimToSlice] == src_view_shape[firstDimToSlice]) {
+      firstDimToSlice++;
+    }
+
+    int x = 1;
+    for (int el = firstDimToSlice + 1; el < src_base_shape.size(); el++) {
+      x *= src_base_shape[el];
+    }
+
+    int sliceOffset = src.storage_offset() / x;
+    // There are cases where both dimensions of a view can shrink
+    // E.g: x = torch.randn((3,6))[1, 1:3]
+    int nextSliceOffset = src.storage_offset() % x;
+
+    [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), src.sizes()[firstDimToSlice]}];
+    if (nextSliceOffset) {
+      [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 2 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(nextSliceOffset), src.sizes()[firstDimToSlice+1]}];
+    }
+  }
+  else {
+    int src_view_numel = 1;
+    for (int i = 0; i < src_ndim_view; i++) {
+      src_view_numel *= src_view_shape[i];
+    }
+
+    int idx = 0;
+    int finalShapeSize = (src_ndim_view == 0) ? 1 : src_ndim_view;
+    std::vector<NSNumber*> mpsFinalShape(finalShapeSize);
+
+    // When the shapes are different, we need to flatten the first slice in order to alias the memory without any copies
+    // E.g: base tensor [5, 7, 3], view tensor [7, 3] (storage_offset=21). We need to flatten [5, 7, 3] to [35, 3], then
+    // we can slice directly into the first dimension based on the storage_offset
+    uint32_t flattenedSlice = 1;
+    for (int i = 0; i < src_ndim_base - finalShapeSize + 1; i++) {
+      flattenedSlice *= src_base_shape[i];
+    }
+    mpsFinalShape[idx++] = [NSNumber numberWithInteger:flattenedSlice];
+
+    for (int i = src_ndim_base - finalShapeSize + 1; i < src_ndim_base; i++) {
+      mpsFinalShape[idx++] = [NSNumber numberWithInteger:src_base_shape[i]];
+    }
+
+    mpsShape = [NSArray arrayWithObjects:mpsFinalShape.data() count:mpsFinalShape.size()];
+    srcTensorNDArray = ndArrayFromTensor(src, mpsShape, mpsDataType);
+    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
+
+    int dim0 = (src_ndim_view == 0) ? 1 : src_view_shape[0];
+    int totalSlices = dim0;
+
+    // For 1D arrays, the storage_offset gives directly the
+    // starting point from where the slice should start
+    int sliceOffset = src_ndim_view == 1 ? 1 : dim0;
+    int view_numel = src_ndim_view == 1 ? 1 : src_view_numel;
+    [srcTensorNDArrayDesc sliceDimension:finalShapeSize - 1 withSubrange:{static_cast<NSUInteger>((src.storage_offset() / view_numel) * sliceOffset), totalSlices}];
+  }
+
+  srcTensorNDArrayView = [srcTensorNDArray arrayViewWithCommandBuffer:commandBuffer
+                                                           descriptor:srcTensorNDArrayDesc
+                                                             aliasing:MPSAliasingStrategyShallAlias];
+
+  return [[[MPSGraphTensorData alloc] initWithMPSNDArray:srcTensorNDArrayView] autorelease];
+}
+
 Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSShape *mpsShape, bool gatherTensorData) : _tensor(src)
 {
   TORCH_CHECK(src.is_mps(), "Placeholder storage has not been allocated on MPS device!");
   // extract the pointer to MTLBuffer from the Tensor's storage
   id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
   // a view tensor could be contiguous (e.g., slice ops) or non-contiguous (e.g., transpose())
-  if ((src.is_view() || !src.is_contiguous()) && gatherTensorData) {
+  if (!src.is_contiguous() && gatherTensorData) {
      Tensor emptyShell = Tensor();
     // use "_tensor" from Placeholder to retain view's output during its usage in other ops
     _tensor = gatherViewTensor(src, emptyShell);
@@ -183,18 +285,25 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSS
     }
     srcBuf = getMTLBufferStorage(_tensor);
   }
+
   // tensor.numel() could be zero, but tensor is valid as long as the buffer size is non-zero.
   // if buffer size is zero in here, it's not a user error. It could be a missing check for
   // tensor.numel() == 0 in our internal implementations of ops.
   TORCH_INTERNAL_ASSERT([srcBuf length] > 0, "Placeholder tensor is empty!");
-
   const MPSDataType mpsDataType = _tensor.dim() == 0 ? getMPSScalarType(_tensor.scalar_type()) : getMPSDataType(_tensor.scalar_type());
-  if (!mpsShape)
-    mpsShape = getMPSShape(_tensor);
 
-  _value = [[[MPSGraphTensorData alloc] initWithMTLBuffer:srcBuf
-                                                    shape:mpsShape
-                                                 dataType:mpsDataType] autorelease];
+  if (src.is_view() && src.is_contiguous() && src.storage_offset()) {
+    _value = getMPSGraphTensorDataForView(src, mpsShape, mpsDataType);
+  } else {
+    if (!mpsShape) {
+      mpsShape = getMPSShape(_tensor);
+    }
+
+    _value = [[[MPSGraphTensorData alloc] initWithMTLBuffer:srcBuf
+                                                      shape:mpsShape
+                                                   dataType:mpsDataType] autorelease];
+  }
+
   TORCH_INTERNAL_ASSERT(_value);
   _placeholder = mpsGraphTensor;
 }

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -417,6 +417,95 @@ MPSGraphTensor* asStridedLayer_pattern(MPSGraph *graph, MPSGraphTensor *inputTen
   return outputTensor;
 }
 
+MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mpsShape, const MPSDataType mpsDataType) {
+  IntArrayRef src_base_shape = get_buffer_shape(src.storage().data());
+  std::vector<int64_t> src_view_shape;
+  bool hasMPSShape = (mpsShape != nil);
+  int src_ndim_base = src_base_shape.size();
+  int src_ndim_view = 0;
+  if (hasMPSShape) {
+    src_ndim_view = [mpsShape count];
+    src_view_shape.reserve(src_ndim_view);
+    for (const auto i : c10::irange(src_ndim_view)) {
+      src_view_shape[i] = [mpsShape[i] intValue];
+    }
+  } else {
+    src_ndim_view = src.dim();
+    src_view_shape = src.sizes().vec();
+  }
+
+  MPSNDArray *srcTensorNDArrayView = nil;
+  MPSNDArrayDescriptor *srcTensorNDArrayDesc = nil;
+  MPSNDArray *srcTensorNDArray = nil;
+  id<MTLCommandBuffer> commandBuffer = getCurrentMPSStream()->commandBuffer();
+
+  if (src_ndim_base == src_ndim_view) {
+    srcTensorNDArray = ndArrayFromTensor(src, getMPSShape(src_base_shape), mpsDataType);
+    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
+
+    int firstDimToSlice = 0;
+    while (src_base_shape[firstDimToSlice] == src_view_shape[firstDimToSlice]) {
+      firstDimToSlice++;
+    }
+
+    int view_numel = 1;
+    for (const auto i : c10::irange(firstDimToSlice + 1, src_base_shape.size())) {
+      view_numel *= src_base_shape[i];
+    }
+
+    int sliceOffset = src.storage_offset() / view_numel;
+    // There are cases where both dimensions of a view can shrink
+    // E.g: x = torch.randn((3,6))[1, 1:3]
+    int nextSliceOffset = src.storage_offset() % view_numel;
+
+    [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), src.sizes()[firstDimToSlice]}];
+    if (nextSliceOffset) {
+      [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 2 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(nextSliceOffset), src.sizes()[firstDimToSlice+1]}];
+    }
+  }
+  else {
+    int src_view_numel = 1;
+    for (const auto i : c10::irange(src_ndim_view)) {
+      src_view_numel *= src_view_shape[i];
+    }
+
+    int idx = 0;
+    int finalShapeSize = (src_ndim_view == 0) ? 1 : src_ndim_view;
+    std::vector<NSNumber*> mpsFinalShape(finalShapeSize);
+
+    // When the shapes are different, we need to flatten the first slice in order to alias the memory without any copies
+    // E.g: base tensor [5, 7, 3], view tensor [7, 3] (storage_offset=21). We need to flatten [5, 7, 3] to [35, 3], then
+    // we can slice directly into the first dimension based on the storage_offset
+    uint32_t flattenedSlice = 1;
+    for (const auto i : c10::irange(src_ndim_base - finalShapeSize + 1)) {
+      flattenedSlice *= src_base_shape[i];
+    }
+    mpsFinalShape[idx++] = [NSNumber numberWithInteger:flattenedSlice];
+
+    for (const auto i : c10::irange(src_ndim_base - finalShapeSize + 1, src_ndim_base)) {
+      mpsFinalShape[idx++] = [NSNumber numberWithInteger:src_base_shape[i]];
+    }
+
+    mpsShape = [NSArray arrayWithObjects:mpsFinalShape.data() count:mpsFinalShape.size()];
+    srcTensorNDArray = ndArrayFromTensor(src, mpsShape, mpsDataType);
+    srcTensorNDArrayDesc = srcTensorNDArray.descriptor;
+
+    int dim0 = (src_ndim_view == 0) ? 1 : src_view_shape[0];
+    int totalSlices = dim0;
+
+    // For 1D arrays, the storage_offset gives directly the
+    // starting point from where the slice should start
+    int sliceOffset = src_ndim_view == 1 ? 1 : dim0;
+    int view_numel = src_ndim_view == 1 ? 1 : src_view_numel;
+    [srcTensorNDArrayDesc sliceDimension:finalShapeSize - 1 withSubrange:{static_cast<NSUInteger>((src.storage_offset() / view_numel) * sliceOffset), totalSlices}];
+  }
+
+  srcTensorNDArrayView = [srcTensorNDArray arrayViewWithCommandBuffer:commandBuffer
+                                                           descriptor:srcTensorNDArrayDesc
+                                                             aliasing:MPSAliasingStrategyShallAlias];
+
+  return [[[MPSGraphTensorData alloc] initWithMPSNDArray:srcTensorNDArrayView] autorelease];
+}
 
 static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const IntArrayRef& size,
                                           const IntArrayRef& stride, int64_t offset,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/85297, https://github.com/pytorch/pytorch/issues/86048



Below are the results from the script provided by @Birch-san in https://github.com/pytorch/pytorch/issues/85297#issuecomment-1279625643:

**RC5**:
```
for reference: our sync operation -- on a tensor of our target size -- is responsible for only 0.1339 seconds of overhead
einsum 0 iteration 0 took 0.1471 seconds
einsum 0 iteration 1 took 0.0172 seconds
einsum 0 iteration 2 took 0.0155 seconds
einsum 0 iteration 3 took 0.0153 seconds
einsum 0 iteration 4 took 0.0157 seconds
einsum 0 iteration 5 took 0.0159 seconds
einsum 0 iteration 6 took 0.0158 seconds
einsum 0 iteration 7 took 0.0159 seconds
einsum 0 iteration 8 took 0.0159 seconds
einsum 0 iteration 9 took 0.0159 seconds
10 iterations of einsum 0 took 0.2902 seconds; avg 0.0290 secs
einsum 1 iteration 0 took 0.0275 seconds
einsum 1 iteration 1 took 0.0236 seconds
einsum 1 iteration 2 took 0.0245 seconds
einsum 1 iteration 3 took 0.0236 seconds
einsum 1 iteration 4 took 0.0243 seconds
einsum 1 iteration 5 took 0.0236 seconds
einsum 1 iteration 6 took 0.0240 seconds
einsum 1 iteration 7 took 0.0237 seconds
einsum 1 iteration 8 took 0.0238 seconds
einsum 1 iteration 9 took 0.0235 seconds
10 iterations of einsum 1 took 0.2422 seconds; avg 0.0242 secs
```

**RC5 + contiguous view optimizations** (brings the perf back to where 1.12 was): 
```
for reference: our sync operation -- on a tensor of our target size -- is responsible for only 0.1314 seconds of overhead
einsum 0 iteration 0 took 0.0950 seconds
einsum 0 iteration 1 took 0.0111 seconds
einsum 0 iteration 2 took 0.0097 seconds
einsum 0 iteration 3 took 0.0093 seconds
einsum 0 iteration 4 took 0.0100 seconds
einsum 0 iteration 5 took 0.0095 seconds
einsum 0 iteration 6 took 0.0098 seconds
einsum 0 iteration 7 took 0.0095 seconds
einsum 0 iteration 8 took 0.0093 seconds
einsum 0 iteration 9 took 0.0096 seconds
10 iterations of einsum 0 took 0.1827 seconds; avg 0.0183 secs
einsum 1 iteration 0 took 0.0219 seconds
einsum 1 iteration 1 took 0.0721 seconds
einsum 1 iteration 2 took 0.0177 seconds
einsum 1 iteration 3 took 0.0188 seconds
einsum 1 iteration 4 took 0.0178 seconds
einsum 1 iteration 5 took 0.0182 seconds
einsum 1 iteration 6 took 0.0182 seconds
einsum 1 iteration 7 took 0.0176 seconds
einsum 1 iteration 8 took 0.0178 seconds
einsum 1 iteration 9 took 0.0186 seconds
10 iterations of einsum 1 took 0.2389 seconds; avg 0.0239 secs
```