### PR TITLE
Fix MPSGraph casting issue to MPSDataTypeBool in masked_fill op

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -56,7 +56,7 @@ class TORCH_API MPSDevice {
 
   MTLFunction_t metalIndexingFunction(const std::string &kernel, MTLFunctionConstantValues_t constantValues);
 
-  bool macOS_13_0();
+  bool macOS_13_0_or_newer();
 
   ~MPSDevice();
 

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -27,7 +27,7 @@ MPSDevice* MPSDevice::getInstance() {
   return mps_device.get();
 }
 
-bool MPSDevice::macOS_13_0() {
+bool MPSDevice::macOS_13_0_or_newer() {
   return _macos_13_0_or_newer;
 }
 

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -343,7 +343,7 @@ Tensor& exponential_mps_(Tensor& self, double lambda, c10::optional<Generator> g
 }
 
 Tensor& randperm_out_mps(int64_t n, c10::optional<Generator> generator, Tensor& result) {
-  if (!MPSDevice::getInstance()->macOS_13_0()) {
+  if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
     TORCH_WARN_ONCE("MPS: randperm op is supported natively starting from macOS 13.0. ",
                     "Falling back on CPU. This may have performance implications.");
 

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -310,7 +310,7 @@ _unique_impl_mps(const Tensor& self, const bool return_inverse, const bool retur
 
 std::tuple<Tensor, Tensor, Tensor>
 unique_consecutive_mps(const Tensor& self, const bool return_inverse, const bool return_counts, c10::optional<int64_t> dim) {
-  if (!MPSDevice::getInstance()->macOS_13_0()) {
+  if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
     TORCH_WARN_ONCE("MPS: unique_consecutive op is supported natively starting from macOS 13.0. ",
                     "Falling back on CPU. This may have performace implications.");
     return at::unique_consecutive(self.to("cpu"), return_inverse, return_counts, dim);
@@ -321,7 +321,7 @@ unique_consecutive_mps(const Tensor& self, const bool return_inverse, const bool
 
 std::tuple<Tensor, Tensor, Tensor>
 unique_dim_consecutive_mps(const Tensor& self, int64_t dim, const bool return_inverse, const bool return_counts) {
-  if (!MPSDevice::getInstance()->macOS_13_0()) {
+  if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
     TORCH_WARN_ONCE("MPS: unique_dim_consecutive op is supported natively starting from macOS 13.0. ",
                     "Falling back on CPU. This may have performace implications.");
     return at::unique_dim_consecutive(self.to("cpu"), dim, return_inverse, return_counts);
@@ -332,7 +332,7 @@ unique_dim_consecutive_mps(const Tensor& self, int64_t dim, const bool return_in
 
 std::tuple<Tensor, Tensor, Tensor>
 _unique2_mps(const Tensor& self, const bool sorted, const bool return_inverse, const bool return_counts) {
-  if (!MPSDevice::getInstance()->macOS_13_0()) {
+  if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
     TORCH_WARN_ONCE("MPS: _unique2 op is supported natively starting from macOS 13.0. ",
                     "Falling back on CPU. This may have performace implications.");
     return at::_unique2(self.to("cpu"), sorted, return_inverse, return_counts);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7908,7 +7908,7 @@ class TestConsistency(TestCase):
         'logspace': ['f32', 'i16', 'i32', 'i64', 'u8'],
         'logsumexp': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'lt': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
-        'masked_fill': ['f16', 'i16', 'i32', 'i64'],
+        'masked_fill': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'masked_select': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'matmul': ['f32'],
         'maximum': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
@@ -8032,13 +8032,12 @@ class TestConsistency(TestCase):
         'vsplit': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'vstack': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'zero_': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
-        'where': ['f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
+        'where': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'nonzero': ['f32', 'i16', 'i32', 'i64'],
         'cross': ['f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'linalg.cross': ['f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'unique_consecutive': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'nn.functional.nll_loss': ['f32'],
-        'byte': ['b8', 'i16', 'i32', 'i64', 'u8'],
         }
 
 
@@ -8217,8 +8216,6 @@ class TestConsistency(TestCase):
     # All the entries in this list should be removed
     BLOCKLIST = {
         # Functions that hang
-        'einsum': ['f32'],
-        'masked_fill': [torch.bool, torch.uint8, torch.float32], 'where': [torch.bool],
         # + forward when requires_grad=True or running backward
         'masked.mean': [torch.bool, torch.float16],
         'masked.prod': [torch.bool],


### PR DESCRIPTION
Fixes TestConsistency masked_fill for bool data type.

Casting a tensor > 1 to `MPSDataTypeBool` will result in 0 instead of 1. This change manually casts the scalar to a value of 0 or 1 when casting a non-boolean tensor to a boolean tensor:
```
(inputDataType == MPSDataTypeBool) ? !!value.to<double>() : value.to<double>()
```