### PR TITLE
Clamp argmin / argmax min indicies values to 0

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1620,8 +1620,13 @@ void argmax_argmin_out_mps
                                                           toType:MPSDataTypeInt64
                                                             name:@"castOutputTensor"];
 
+            MPSGraphTensor* outputClampedTensor = [mpsGraph clampWithTensor:outputTensor
+                                                             minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
+                                                             maxValueTensor:[mpsGraph constantWithScalar:LLONG_MAX dataType:MPSDataTypeInt64]
+                                                                       name: nil];
+
             newCachedGraph->inputTensor_ = inputTensor;
-            newCachedGraph->outputTensor_ = outputTensor;
+            newCachedGraph->outputTensor_ = outputClampedTensor;
           }
           return newCachedGraph;
         });

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8001,8 +8001,8 @@ class TestConsistency(TestCase):
         '__ror__': ['b8', 'i16', 'i32', 'i64', 'u8'],
         '__rpow__': ['f16'],
         '__rxor__': ['b8', 'i16', 'i32', 'i64', 'u8'],
-        'masked.argmax': ['i16', 'i64', 'u8'],
-        'masked.argmin': ['i16', 'i64', 'u8'],
+        'masked.argmax': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
+        'masked.argmin': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
         'masked.log_softmax': ['f32'],
         'masked.logaddexp': ['f32'],
         'masked.logsumexp': ['b8', 'f16', 'f32', 'i16', 'i32', 'i64', 'u8'],
@@ -8459,10 +8459,6 @@ class TestConsistency(TestCase):
         '__rpow__': [torch.int64],
         'masked.std': [torch.int32],
         'masked.var': [torch.int32],
-
-        # Failures due to inconsistency between CPU and GPU for `inf` case
-        'masked.argmax': ['f16', 'f32', 'i32'],
-        'masked.argmin': ['f16', 'f32', 'i32'],
 
         'as_strided_scatter': [torch.uint8],
         'atan2': [torch.int64],


### PR DESCRIPTION
Fixes `masked.argmax / masked.argmin`
In case of passing `inf` to argmax / argmin, MPS will return nan as index for these numbers. Casting this `nan` to Long will make it `-1`. This change avoids negative values by clamping them to 0 (matching CPU results).