### PR TITLE
Removed masked_var & masked_std from blocklist

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8010,8 +8010,6 @@ class TestConsistency(TestCase):
         'masked.normalize': ['f16', 'f32'],
         'masked.softmax': ['f32'],
         'masked.softmin': ['f32'],
-        'masked.std': ['f32'],
-        'masked.var': ['f32'],
         'abs': ['b8', 'f16', 'f32', 'i16', 'i32', 'u8'],
         'acos': ['b8', 'f32', 'i16', 'i32', 'u8'],
         'acosh': ['b8', 'f32', 'i16', 'i32', 'u8'],
@@ -8457,8 +8455,6 @@ class TestConsistency(TestCase):
         'stft': [torch.float32],
         # + forward when requires_grad=True or running backward
         '__rpow__': [torch.int64],
-        'masked.std': [torch.int32],
-        'masked.var': [torch.int32],
 
         # Failures due to inconsistency between CPU and GPU for `inf` case
         'masked.argmax': ['f16', 'f32', 'i32'],


### PR DESCRIPTION
Issues with masked_var & masked_std resolved by changes made in https://github.com/kulinseth/pytorch/pull/188. Moving tests to allowlist
