### PR TITLE
Fix masked_fill and masked_mean hangs on macOS Monterey

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -712,7 +712,7 @@ Tensor & masked_fill__mps(Tensor& self, const Tensor & mask, const Scalar& value
 
   MPSDataType inputDataType = getMPSScalarType(self.scalar_type());
   MPSDataType maskDataType = getMPSScalarType(b_mask->scalar_type());
-  // Workaround for `selectWithPredicateTensor` on macOS Monterey when bool data type may cause a hang
+  // Workaround for `selectWithPredicateTensor` on macOS Monterey where bool data type may cause a hang
   // The issue is fixed in macOS Ventura (13.0)
   if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
      if (self.scalar_type() == kBool) {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -722,8 +722,6 @@ Tensor & masked_fill__mps(Tensor& self, const Tensor & mask, const Scalar& value
       maskDataType = MPSDataTypeInt8;
      }
   }
-  if (self.scalar_type() == kBool && mask.scalar_type() == kBool && !MPSDevice::getInstance()->macOS_13_0_or_newer()) {
-  }
 
   MPSStream* stream = getCurrentMPSStream();
   MPSScalar valueScalar = getMPSScalar(value, value.type());

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -321,6 +321,23 @@ Tensor& where_self_out_mps(const Tensor& condition,
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
+  MPSDataType conditionDataType = getMPSScalarType(condition.scalar_type());
+  MPSDataType selfDataType = getMPSScalarType(self.scalar_type());
+  MPSDataType otherDataType = getMPSScalarType(other.scalar_type());
+  // Workaround for `selectWithPredicateTensor` on macOS Monterey when bool data type may cause a hang
+  // The issue is fixed in macOS Ventura (13.0)
+  if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
+     if (condition.scalar_type() == kBool) {
+      conditionDataType = MPSDataTypeInt8;
+     }
+     if (self.scalar_type() == kBool) {
+      selfDataType = MPSDataTypeInt8;
+     }
+     if (other.scalar_type() == kBool) {
+      otherDataType = MPSDataTypeInt8;
+     }
+  }
+
   @autoreleasepool {
 
     string key = "where_self_out_mps:" + getTensorsStringKey({cond_bool, self, other});
@@ -336,9 +353,9 @@ Tensor& where_self_out_mps(const Tensor& condition,
                 MPSGraph* mpsGraph = make_mps_graph();
                 newCachedGraph = new CachedGraph(mpsGraph);
 
-                MPSGraphTensor* conditionTensor = mpsGraphRankedPlaceHolder(mpsGraph, cond_bool);
-                MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-                MPSGraphTensor* otherTensor = mpsGraphRankedPlaceHolder(mpsGraph, other);
+                MPSGraphTensor* conditionTensor = mpsGraphRankedPlaceHolder(mpsGraph, conditionDataType, getMPSShape(cond_bool));
+                MPSGraphTensor* selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, selfDataType, getMPSShape(self));
+                MPSGraphTensor* otherTensor = mpsGraphRankedPlaceHolder(mpsGraph, otherDataType, getMPSShape(other));
 
                 MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:conditionTensor
                                                                truePredicateTensor:selfTensor
@@ -355,9 +372,12 @@ Tensor& where_self_out_mps(const Tensor& condition,
         cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
     }
 
-    Placeholder conditionPlaceholder = Placeholder(cachedGraph->conditionTensor_, cond_bool);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->selfTensor_, self);
-    Placeholder otherPlaceholder = Placeholder(cachedGraph->otherTensor_, other);
+    Placeholder conditionPlaceholder = Placeholder(
+        cachedGraph->conditionTensor_, cond_bool, /*mpsShape=*/nullptr, /*gatherTensorData=*/true, conditionDataType);
+    Placeholder selfPlaceholder = Placeholder(
+        cachedGraph->selfTensor_, self, /*mpsShape=*/nullptr, /*gatherTensorData=*/true, selfDataType);
+    Placeholder otherPlaceholder = Placeholder(
+        cachedGraph->otherTensor_, other, /*mpsShape=*/nullptr, /*gatherTensorData=*/true, otherDataType);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -324,7 +324,7 @@ Tensor& where_self_out_mps(const Tensor& condition,
   MPSDataType conditionDataType = getMPSScalarType(condition.scalar_type());
   MPSDataType selfDataType = getMPSScalarType(self.scalar_type());
   MPSDataType otherDataType = getMPSScalarType(other.scalar_type());
-  // Workaround for `selectWithPredicateTensor` on macOS Monterey when bool data type may cause a hang
+  // Workaround for `selectWithPredicateTensor` on macOS Monterey where bool data type may cause a hang
   // The issue is fixed in macOS Ventura (13.0)
   if (!MPSDevice::getInstance()->macOS_13_0_or_newer()) {
      if (condition.scalar_type() == kBool) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8746,6 +8746,9 @@ class TestConsistency(TestCase):
                 elif (op.name == "add" or op.name == "sub" or op.name == "nn.functional.huber_loss") and dtype == torch.float16:
                     atol = 1e-2
                     rtol = 1e-2
+                elif (op.name == "masked.mean"):
+                    atol = 7e-4
+                    rtol = 2e-3
                 else:
                     atol = None
                     rtol = None


### PR DESCRIPTION
Fix `masked_fill` and `masked_mean` hang for bool data type on macOS Monterey.

`selectWithPredicateTensor` hangs the machine when using bool data type on macOS Monterey (this is fixed in Ventura). Instead of using bool, this PR changes the input data type to int8.