### PR TITLE
Fix ops with bool issues in macOS Monterey

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -89,7 +89,7 @@ MPSGraphTensor* trunc_tensor(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
 MPSGraphTensor* convertNHWCtoNCHW(MPSGraph *mpsGraph, MPSGraphTensor* tensor);
 MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, ScalarType toType);
 MPSGraphTensorData *getMPSGraphTensorData(MPSGraph* mpsGraph, MPSStream* mpsStream, const Tensor& tensor);
-MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar);
+MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar, MPSDataType dataType = MPSDataTypeInvalid);
 
 MPSGraph* make_mps_graph();
 void printTensorNDArray(const Tensor& t);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -307,14 +307,14 @@ MPSScalar getMPSScalar(const Scalar& scalar, ScalarType type) {
   }
 }
 
-MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar) {
+MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar, MPSDataType dataType) {
   MPSGraphTensorData *result = nullptr;
   // Scalar pools are only supported on devices with unified memory
   if (mpsStream->device().hasUnifiedMemory) {
     scalar.buffer = at::mps::allocate_scalar_buffer(&scalar.value, scalar.size);
     result = [[[MPSGraphTensorData alloc] initWithMTLBuffer: scalar.getMTLBuffer()
                                                       shape: @[@1]
-                                                   dataType: getMPSScalarType(scalar.type)] autorelease];
+                                                   dataType: (dataType != MPSDataTypeInvalid) ? dataType : getMPSScalarType(scalar.type)] autorelease];
   } else {
     MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:getMPSScalarType(scalar.type) shape:@[@1]];
     MPSNDArray *tensorNDArray = [[[MPSNDArray alloc] initWithDevice:mpsStream->device() descriptor:tensorDesc] autorelease];

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -54,6 +54,21 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
     needsCopyToOutput = true;
   }
 
+  auto inputDataType = self.scalar_type();
+  auto otherDataType = other.scalar_type();
+  auto outputDataType = output_.scalar_type();
+  if (!is_macos_13_or_newer()) {
+    if (self.scalar_type() == kBool) {
+      inputDataType = kChar;
+    }
+    if (other.scalar_type() == kBool) {
+      otherDataType = kChar;
+    }
+    if (output.scalar_type() == kBool) {
+      outputDataType = kChar;
+    }
+  }
+
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, other, output_}, /*use_scalar_value*/ false);
@@ -65,35 +80,35 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
         @autoreleasepool {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new BinaryOpCachedGraph(mpsGraph);
-          newCachedGraph->primaryTensor   = mpsGraphRankedPlaceHolder(mpsGraph, self);
-          newCachedGraph->secondaryTensor = mpsGraphRankedPlaceHolder(mpsGraph, other);
+          newCachedGraph->primaryTensor   = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType), getMPSShape(self));
+          newCachedGraph->secondaryTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType), getMPSShape(other));
 
           MPSGraphTensor* primaryCastTensor   = newCachedGraph->primaryTensor;
           MPSGraphTensor* secondaryCastTensor = newCachedGraph->secondaryTensor;
 
           // this type inference is only required at the time of graph creation
-          ScalarType common_dtype = c10::promoteTypes(self.scalar_type(), other.scalar_type());
+          ScalarType common_dtype = c10::promoteTypes(inputDataType, otherDataType);
           if (isIntegralType(common_dtype, true)) {
             // integer inputs must be cast to float, if output is float
             if (isFloatingType(output_.scalar_type())) {
               common_dtype = output_.scalar_type();
             // in boolean comparison ops with signed vs. unsigned integers, we always cast to the unsigned type
-            } else if (output_.scalar_type() == ScalarType::Bool &&
-                      (self.scalar_type()  == ScalarType::Byte ||
-                       other.scalar_type() == ScalarType::Byte)) {
+            } else if (outputDataType == ScalarType::Bool &&
+                      (inputDataType  == ScalarType::Byte ||
+                       otherDataType  == ScalarType::Byte)) {
               common_dtype = ScalarType::Byte;
             }
           }
-          if (self.scalar_type() != common_dtype) {
+          if (inputDataType != common_dtype) {
             primaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->primaryTensor, common_dtype);
           }
-          if (other.scalar_type() != common_dtype) {
+          if (otherDataType != common_dtype) {
             secondaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->secondaryTensor, common_dtype);
           }
           newCachedGraph->outputTensor = binaryBlock(newCachedGraph, primaryCastTensor, secondaryCastTensor);
           // Cast output tensor to an expected type if needed, which addresses discrepancy when int64 scalar is added to int32 tensor
           // Output tensor should have been promoted but it remains an int32 tensor
-          if (output_.scalar_type() != common_dtype) {
+          if (outputDataType != common_dtype) {
             newCachedGraph->outputTensor = castMPSTensor(mpsGraph, newCachedGraph->outputTensor, output_.scalar_type());
           }
         }
@@ -111,16 +126,18 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
 
     if (is_self_scalar && !self.is_mps()) {
       self_scalar = getMPSScalar(self.item(), self.scalar_type());
-      feeds[cachedGraph->primaryTensor] = getMPSGraphTensorFromScalar(mpsStream, self_scalar);
+      feeds[cachedGraph->primaryTensor] = getMPSGraphTensorFromScalar(mpsStream, self_scalar, getMPSScalarType(inputDataType));
     } else {
-      selfPlaceholder = Placeholder(cachedGraph->primaryTensor, self);
+      selfPlaceholder = Placeholder(
+        cachedGraph->primaryTensor, self,  /*mpsShape*/nil, /*gatherTensorData=*/true, getMPSScalarType(inputDataType));
       feeds[selfPlaceholder.getMPSGraphTensor()] = selfPlaceholder.getMPSGraphTensorData();
     }
     if (is_other_scalar && !other.is_mps()) {
       other_scalar = getMPSScalar(other.item(), other.scalar_type());
-      feeds[cachedGraph->secondaryTensor] = getMPSGraphTensorFromScalar(mpsStream, other_scalar);
+      feeds[cachedGraph->secondaryTensor] = getMPSGraphTensorFromScalar(mpsStream, other_scalar, getMPSScalarType(otherDataType));
     } else {
-      otherPlaceholder = Placeholder(cachedGraph->secondaryTensor, other);
+      otherPlaceholder = Placeholder(
+        cachedGraph->secondaryTensor, other,  /*mpsShape*/nil, /*gatherTensorData=*/true, getMPSScalarType(otherDataType));
       feeds[otherPlaceholder.getMPSGraphTensor()] = otherPlaceholder.getMPSGraphTensorData();
     }
 
@@ -130,7 +147,8 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
       feeds[cachedGraph->alphaTensor] = getMPSGraphTensorFromScalar(mpsStream, alpha_scalar);
     }
 
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, needsCopyToOutput ? output : output_);
+    Placeholder outputPlaceholder = Placeholder(
+      cachedGraph->outputTensor, needsCopyToOutput ? output : output_,  /*mpsShape*/nil, /*gatherTensorData=*/false, getMPSScalarType(outputDataType));
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -440,7 +440,16 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
   using CachedGraph = mps::MPSUnaryCachedGraph;
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
+  MPSDataType inputDataType = getMPSScalarType(self.scalar_type());
+  MPSDataType outputDataType = getMPSScalarType(self.scalar_type());
+  if (!is_macos_13_or_newer()) {
+     if (self.scalar_type() == kBool) {
+      inputDataType = MPSDataTypeInt8;
+     }
+     if (result.scalar_type() == kBool) {
+      outputDataType = MPSDataTypeInt8;
+     }
+  }
   @autoreleasepool {
     NSString* ns_dims_key = [[ns_dims valueForKey:@"description"] componentsJoinedByString:@","];
     // A key is used to identify the MPSGraph which was created once, and can be reused if the parameters, data types etc match the earlier created MPSGraph
@@ -455,7 +464,7 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(self));
           MPSGraphTensor* outputTensor = [mpsGraph reverseTensor:inputTensor
                                                             axes:ns_dims
                                                             name:nil];
@@ -467,8 +476,10 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
     }
 
     // Create placeholders which use the keys of the CachedGraph to create inputs and outputs of the operation
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
+    Placeholder inputPlaceholder = Placeholder(
+      cachedGraph->inputTensor_, self, /*mpsShape*/nil, /*gatherTensorData=*/true, inputDataType);
+    Placeholder outputPlaceholder = Placeholder(
+      cachedGraph->outputTensor_, result, /*mpsShape*/nil, /*gatherTensorData=*/false, outputDataType);
 
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
@@ -635,9 +646,16 @@ Tensor& index_select_out_mps(const Tensor & self,
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   auto inputType = getMPSDataType(self.scalar_type());
-  if (inputType ==  MPSDataTypeUInt8) {
-      inputType =  MPSDataTypeInt8;
+  auto outputType = getMPSDataType(output.scalar_type());
+  if (inputType == MPSDataTypeUInt8 ||
+     (!is_macos_13_or_newer() && inputType == MPSDataTypeBool)) {
+    inputType = MPSDataTypeInt8;
   }
+  if (outputType == MPSDataTypeUInt8 ||
+     (!is_macos_13_or_newer() && outputType == MPSDataTypeBool)) {
+    outputType = MPSDataTypeInt8;
+  }
+
   @autoreleasepool {
 
     string key = "index_select_out_mps" + getTensorsStringKey({self, index}) + ":" + std::to_string(dim);
@@ -672,7 +690,7 @@ Tensor& index_select_out_mps(const Tensor & self,
                                   /*mpsShape=*/nullptr, /*gatherTensorData=*/true, /*dataType=*/inputType);
     Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output,
-                                  /*mpsShape=*/nullptr, /*gatherTensorData=*/false, /*dataType=*/inputType);
+                                  /*mpsShape=*/nullptr, /*gatherTensorData=*/false, /*dataType=*/outputType);
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
       selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData(),
@@ -764,10 +782,11 @@ Tensor & masked_fill__mps(Tensor& self, const Tensor & mask, const Scalar& value
     }
 
     Placeholder selfPlaceholder   = Placeholder(
-      cachedGraph->inputTensor_, self, /*mpsShape*/nullptr, /*gatherTensorData=*/true, inputDataType);
+      cachedGraph->inputTensor_, self, /*mpsShape*/nil, /*gatherTensorData=*/true, inputDataType);
     Placeholder maskPlaceholder   = Placeholder(
-      cachedGraph->maskTensor_, *b_mask, /*mpsShape*/nullptr, /*gatherTensorData=*/true, maskDataType);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, self);
+      cachedGraph->maskTensor_, *b_mask, /*mpsShape*/nil, /*gatherTensorData=*/true, maskDataType);
+    Placeholder outputPlaceholder = Placeholder(
+      cachedGraph->outputTensor_, self, /*mpsShape*/nil, /*gatherTensorData=*/false, inputDataType);
 
     // Create dictionary of inputs and outputs
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -72,6 +72,16 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
   }
 
   auto stream = at::mps::getCurrentMPSStream();
+  auto inputDataType = getMPSDataType(expanded_tensor.scalar_type());
+  auto outputDataType = getMPSDataType(result.scalar_type());
+  if (!is_macos_13_or_newer()) {
+     if (expanded_tensor.scalar_type() == kBool) {
+      inputDataType = MPSDataTypeInt8;
+     }
+     if (result.scalar_type() == kBool) {
+      outputDataType = MPSDataTypeInt8;
+     }
+  }
 
   @autoreleasepool {
     string key = "repeat_mps:" + getTensorsStringKey(self) + ":" + getArrayRefString(repeats);
@@ -85,7 +95,7 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, expanded_tensor);
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, inputDataType, getMPSShape(expanded_tensor));
           MPSGraphTensor* outputTensor = [mpsGraph tileTensor:inputTensor
                                                withMultiplier:getMPSShape(repeats)
                                                          name:nil];
@@ -98,8 +108,10 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
       cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
     }
 
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, expanded_tensor);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
+    Placeholder selfPlaceholder = Placeholder(
+      cachedGraph->inputTensor_, expanded_tensor, /*mpsShape=*/nil, /*gatherTensorData=*/true, inputDataType);
+    Placeholder outputPlaceholder = Placeholder(
+      cachedGraph->outputTensor_, result, /*mpsShape=*/nil, /*gatherTensorData*/false, outputDataType);
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
       selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData()

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -281,160 +281,171 @@ TORCH_IMPL_FUNC(cumsum_out_mps)
 
 TORCH_IMPL_FUNC(sgn_out_mps) (const Tensor& self, const Tensor& output)
 {
-    using namespace mps;
+  using namespace mps;
 
-    if (self.numel() == 0)
-      return;
+  if (self.numel() == 0) {
+    return;
+  }
 
-    if (!output.is_same_size(self)) {
-      output.resize_(self.sizes());
+  if (!output.is_same_size(self)) {
+    output.resize_(self.sizes());
+  }
+
+  string graphSuffix = "_real";
+  Tensor realInput;
+  Tensor realOutput;
+  Tensor flatInput = self.flatten();
+  Tensor flatOutput = output.flatten();
+  if (self.is_complex()) {
+    realInput = at::view_as_real(flatInput);
+    realOutput = at::view_as_real(flatOutput);
+    graphSuffix = "_complex";
+  } else {
+    realInput = flatInput;
+    realOutput = flatOutput;
+  }
+
+  MPSDataType selfDataType = getMPSScalarType(self.scalar_type());
+  // Workaround for `constantWithScalar` crashes due to unsupported bool data type
+  // The issue is fixed in macOS Ventura (13.0)
+  if (!is_macos_13_or_newer()) {
+     if (self.scalar_type() == kBool) {
+      selfDataType = MPSDataTypeInt8;
+     }
+  }
+
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+  @autoreleasepool {
+    string key = string("sgn_out_mps") + getTensorsStringKey({realInput}) + graphSuffix;
+    auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
+
+    if(!cachedGraph) {
+      MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph* () {
+        MPSUnaryCachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
+          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, selfDataType, getMPSShape(realInput));
+            MPSGraphTensor* sgnTensor;
+            if (self.is_complex()) {
+              NSArray<MPSGraphTensor*>* complexNumberComponents = [mpsGraph splitTensor:newCachedGraph->inputTensor_
+                                                            numSplits: 2
+                                                            axis: 1
+                                                            name: nil];
+
+              MPSGraphTensor* realPartTensor = complexNumberComponents[0];
+              MPSGraphTensor* imaginaryPartTensor = complexNumberComponents[1];
+
+              MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0
+                                                            shape:realPartTensor.shape
+                                                            dataType:realPartTensor.dataType];
+
+              MPSGraphTensor* complexZeroTensor = [mpsGraph constantWithScalar:0.0
+                                                            shape: newCachedGraph->inputTensor_.shape
+                                                            dataType:realPartTensor.dataType];
+
+              MPSGraphTensor* isRealZero = [mpsGraph equalWithPrimaryTensor:realPartTensor
+                                                            secondaryTensor:zeroTensor
+                                                            name: nil];
+
+              MPSGraphTensor* isImaginaryZero = [mpsGraph equalWithPrimaryTensor:imaginaryPartTensor
+                                                            secondaryTensor:zeroTensor
+                                                            name: nil];
+
+              MPSGraphTensor* isComplexZero = [mpsGraph logicalANDWithPrimaryTensor:isRealZero
+                                                            secondaryTensor:isImaginaryZero
+                                                            name: nil];
+
+              MPSGraphTensor* sgnDenomReal = [mpsGraph squareWithTensor:realPartTensor
+                                                            name: nil];
+
+              MPSGraphTensor* sgnDenomImaginary = [mpsGraph squareWithTensor:imaginaryPartTensor
+                                                            name: nil];
+
+              MPSGraphTensor* sgnDenomSum = [mpsGraph additionWithPrimaryTensor:sgnDenomReal
+                                                            secondaryTensor:sgnDenomImaginary
+                                                            name: nil];
+
+              MPSGraphTensor* sgnDenom = [mpsGraph squareRootWithTensor:sgnDenomSum
+                                                            name: nil];
+
+              MPSGraphTensor* sgnRealTensor = [mpsGraph divisionWithPrimaryTensor:realPartTensor
+                                                            secondaryTensor:sgnDenom
+                                                            name: nil];
+
+              MPSGraphTensor* sgnImaginaryTensor = [mpsGraph divisionWithPrimaryTensor:imaginaryPartTensor
+                                                            secondaryTensor:sgnDenom
+                                                            name: nil];
+
+              MPSGraphTensor* sgnComplexTensor = [mpsGraph concatTensors:@[sgnRealTensor, sgnImaginaryTensor]
+                                                            dimension: 1
+                                                            name: nil];
+
+              sgnTensor = [mpsGraph selectWithPredicateTensor:isComplexZero
+                                                            truePredicateTensor:complexZeroTensor
+                                                            falsePredicateTensor:sgnComplexTensor
+                                                            name:nil];
+            } else {
+              MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0
+                                                            shape:newCachedGraph->inputTensor_.shape
+                                                            dataType:selfDataType];
+
+              MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1
+                                                            shape:newCachedGraph->inputTensor_.shape
+                                                            dataType:selfDataType];
+
+              MPSGraphTensor* negativeOneTensor = [mpsGraph constantWithScalar:-1
+                                                            shape:newCachedGraph->inputTensor_.shape
+                                                            dataType:selfDataType];
+
+              MPSGraphTensor* isPositive = [mpsGraph greaterThanWithPrimaryTensor:newCachedGraph->inputTensor_
+                                                            secondaryTensor:zeroTensor
+                                                            name: nil];
+
+              MPSGraphTensor* isNegative = [mpsGraph lessThanWithPrimaryTensor:newCachedGraph->inputTensor_
+                                                            secondaryTensor:zeroTensor
+                                                            name: nil];
+
+              MPSGraphTensor* notPositiveTensor = [mpsGraph selectWithPredicateTensor:isNegative
+                                                            truePredicateTensor:negativeOneTensor
+                                                            falsePredicateTensor:zeroTensor
+                                                            name:nil];
+
+              sgnTensor = [mpsGraph selectWithPredicateTensor:isPositive
+                                                            truePredicateTensor:oneTensor
+                                                            falsePredicateTensor:notPositiveTensor
+                                                            name:nil];
+            }
+            newCachedGraph->outputTensor_ = sgnTensor;
+        }
+        return newCachedGraph;
+      });
+      cachedGraph = tmpCachedGraph->as<MPSUnaryCachedGraph>();
     }
 
-    string graphSuffix = "_real";
-    Tensor realInput;
-    Tensor realOutput;
-    Tensor flatInput = self.flatten();
-    Tensor flatOutput = output.flatten();
-    if (self.is_complex()) {
-      realInput = at::view_as_real(flatInput);
-      realOutput = at::view_as_real(flatOutput);
-      graphSuffix = "_complex";
-    } else {
-      realInput = flatInput;
-      realOutput = flatOutput;
-    }
+    Placeholder selfPlaceholder = Placeholder(
+      cachedGraph->inputTensor_, realInput, /*mpsShape*/nullptr, /*gatherTensorData=*/true, selfDataType);
+    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, realOutput);
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
+      selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData()
+    };
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
+    };
+    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+  }
 
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-    @autoreleasepool {
-      string key = string("sgn_out_mps") + getTensorsStringKey({realInput}) + graphSuffix;
-      auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
+  if (self.is_complex()) {
+    std::vector<long long> realSize = self.sizes().vec();
+    realSize.push_back(2);
 
-      if(!cachedGraph) {
-        MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph* () {
-          MPSUnaryCachedGraph *newCachedGraph = nil;
-          @autoreleasepool {
-            MPSGraph* mpsGraph = make_mps_graph();
-            newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
-            newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, realInput);
-              MPSGraphTensor* sgnTensor = nullptr;
-              if (self.is_complex()) {
-                NSArray<MPSGraphTensor*>* complexNumberComponents = [mpsGraph splitTensor:newCachedGraph->inputTensor_
-                                                              numSplits: 2
-                                                              axis: 1
-                                                              name: nil];
-
-                MPSGraphTensor* realPartTensor = complexNumberComponents[0];
-                MPSGraphTensor* imaginaryPartTensor = complexNumberComponents[1];
-
-                MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0
-                                                              shape:realPartTensor.shape
-                                                              dataType:realPartTensor.dataType];
-
-                MPSGraphTensor* complexZeroTensor = [mpsGraph constantWithScalar:0.0
-                                                              shape: newCachedGraph->inputTensor_.shape
-                                                              dataType:realPartTensor.dataType];
-
-                MPSGraphTensor* isRealZero = [mpsGraph equalWithPrimaryTensor:realPartTensor
-                                                              secondaryTensor:zeroTensor
-                                                              name: nil];
-
-                MPSGraphTensor* isImaginaryZero = [mpsGraph equalWithPrimaryTensor:imaginaryPartTensor
-                                                              secondaryTensor:zeroTensor
-                                                              name: nil];
-
-                MPSGraphTensor* isComplexZero = [mpsGraph logicalANDWithPrimaryTensor:isRealZero
-                                                              secondaryTensor:isImaginaryZero
-                                                              name: nil];
-
-                MPSGraphTensor* sgnDenomReal = [mpsGraph squareWithTensor:realPartTensor
-                                                              name: nil];
-
-                MPSGraphTensor* sgnDenomImaginary = [mpsGraph squareWithTensor:imaginaryPartTensor
-                                                              name: nil];
-
-                MPSGraphTensor* sgnDenomSum = [mpsGraph additionWithPrimaryTensor:sgnDenomReal
-                                                              secondaryTensor:sgnDenomImaginary
-                                                              name: nil];
-
-                MPSGraphTensor* sgnDenom = [mpsGraph squareRootWithTensor:sgnDenomSum
-                                                              name: nil];
-
-                MPSGraphTensor* sgnRealTensor = [mpsGraph divisionWithPrimaryTensor:realPartTensor
-                                                              secondaryTensor:sgnDenom
-                                                              name: nil];
-
-                MPSGraphTensor* sgnImaginaryTensor = [mpsGraph divisionWithPrimaryTensor:imaginaryPartTensor
-                                                              secondaryTensor:sgnDenom
-                                                              name: nil];
-
-                MPSGraphTensor* sgnComplexTensor = [mpsGraph concatTensors:@[sgnRealTensor, sgnImaginaryTensor]
-                                                              dimension: 1
-                                                              name: nil];
-
-                sgnTensor = [mpsGraph selectWithPredicateTensor:isComplexZero
-                                                              truePredicateTensor:complexZeroTensor
-                                                              falsePredicateTensor:sgnComplexTensor
-                                                              name:nil];
-              } else {
-                MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0
-                                                              shape:newCachedGraph->inputTensor_.shape
-                                                              dataType:mps::getMPSDataType(self.scalar_type())];
-
-                MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1
-                                                              shape:newCachedGraph->inputTensor_.shape
-                                                              dataType:mps::getMPSDataType(self.scalar_type())];
-
-                MPSGraphTensor* negativeOneTensor = [mpsGraph constantWithScalar:-1
-                                                              shape:newCachedGraph->inputTensor_.shape
-                                                              dataType:mps::getMPSDataType(self.scalar_type())];
-
-                MPSGraphTensor* isPositive = [mpsGraph greaterThanWithPrimaryTensor:newCachedGraph->inputTensor_
-                                                              secondaryTensor:zeroTensor
-                                                              name: nil];
-
-                MPSGraphTensor* isNegative = [mpsGraph lessThanWithPrimaryTensor:newCachedGraph->inputTensor_
-                                                              secondaryTensor:zeroTensor
-                                                              name: nil];
-
-                MPSGraphTensor* notPositiveTensor = [mpsGraph selectWithPredicateTensor:isNegative
-                                                              truePredicateTensor:negativeOneTensor
-                                                              falsePredicateTensor:zeroTensor
-                                                              name:nil];
-
-                sgnTensor = [mpsGraph selectWithPredicateTensor:isPositive
-                                                              truePredicateTensor:oneTensor
-                                                              falsePredicateTensor:notPositiveTensor
-                                                              name:nil];
-              }
-              newCachedGraph->outputTensor_ = sgnTensor;
-          }
-          return newCachedGraph;
-        });
-        cachedGraph = tmpCachedGraph->as<MPSUnaryCachedGraph>();
-      }
-
-      Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, realInput);
-      Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, realOutput);
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
-        selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData()
-      };
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
-        outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
-      };
-      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
-    }
-
-    if (self.is_complex()) {
-      std::vector<long long> realSize = self.sizes().vec();
-      realSize.push_back(2);
-
-      Tensor originalShape = realOutput.reshape(realSize);
-      Tensor complexOutput = at::view_as_complex(originalShape);
-      output.copy_(complexOutput);
-    } else {
-      Tensor originalShape = at::reshape(realOutput, self.sizes());
-      output.copy_(originalShape);
-    }
+    Tensor originalShape = realOutput.reshape(realSize);
+    Tensor complexOutput = at::view_as_complex(originalShape);
+    output.copy_(complexOutput);
+  } else {
+    Tensor originalShape = at::reshape(realOutput, self.sizes());
+    output.copy_(originalShape);
+  }
 }
 
 } // namespace native


### PR DESCRIPTION
Summary:
- Remove redundant bool casts from scatter/gather
- Make the workarounds for scatter/gather (for bool/uint8 data types) OS specific - use them only in macOS Monterey, ignore them starting with macOS Ventura 
- Make all tensors ranked in scatter

Fixes following tests: 
```
test_output_match_slice_scatter_cpu_bool
test_output_match_select_scatter_cpu_bool
test_output_match_diagonal_scatter_cpu_bool
test_output_match_repeat_cpu_bool
test_output_match_rot90_cpu_bool
etc..
```

Still failing on macOS Monterey (needs additional investigation):
```
test_output_match_scatter_cpu_bool
```
