### PR TITLE
Fix the crash in sgn_out_mps()

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -283,6 +283,9 @@ TORCH_IMPL_FUNC(sgn_out_mps) (const Tensor& self, const Tensor& output)
 {
     using namespace mps;
 
+    if (self.numel() == 0)
+      return;
+
     if (!output.is_same_size(self)) {
       output.resize_(self.sizes());
     }
@@ -313,7 +316,7 @@ TORCH_IMPL_FUNC(sgn_out_mps) (const Tensor& self, const Tensor& output)
             MPSGraph* mpsGraph = make_mps_graph();
             newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
             newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, realInput);
-              MPSGraphTensor* sgnTensor;
+              MPSGraphTensor* sgnTensor = nullptr;
               if (self.is_complex()) {
                 NSArray<MPSGraphTensor*>* complexNumberComponents = [mpsGraph splitTensor:newCachedGraph->inputTensor_
                                                               numSplits: 2
@@ -329,7 +332,7 @@ TORCH_IMPL_FUNC(sgn_out_mps) (const Tensor& self, const Tensor& output)
 
                 MPSGraphTensor* complexZeroTensor = [mpsGraph constantWithScalar:0.0
                                                               shape: newCachedGraph->inputTensor_.shape
-                                                              dataType:realPartTensor.dataType];                
+                                                              dataType:realPartTensor.dataType];
 
                 MPSGraphTensor* isRealZero = [mpsGraph equalWithPrimaryTensor:realPartTensor
                                                               secondaryTensor:zeroTensor


### PR DESCRIPTION
This should fix the crash with `TestConsistencyCPU.test_output_match_nn_functional_softsign_cpu`