### PR TITLE
Fix the crash in max_out_mps() caused by cached key conflict

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1433,7 +1433,7 @@ void min_max_out_mps
     auto stream = at::mps::getCurrentMPSStream();
 
     @autoreleasepool {
-        string key = func_name + ":" + to_string(dim_) + ":" + native_mps::getMPSTypeString(input_t.scalar_type());
+        string key = func_name + native_mps::getTensorsStringKey({input_t, indices_t}) + ":" + to_string(dim_);
         CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
         if(!cachedGraph) {


### PR DESCRIPTION
- The shape of input and indices tensors were missing in the cached key
- Use the following to repro the crash:
`python test/test_mps.py -v TestConsistencyCPU.test_output_match_max_reduction_with_dim_cpu_float32 TestNLLLoss.test_max_el`
