### PR TITLE
Fix unrecognized selector build warnings in macOS Monterey

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -33,4 +33,60 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
 
 - (MPSGraphTensor * _Nonnull)inverseOfTensor:(MPSGraphTensor * _Nonnull) inputTensor
                                        name:(NSString * _Nullable)name;
+
+- (MPSGraphTensor * _Nonnull) resizeNearestWithTensor:(MPSGraphTensor * _Nonnull) imagesTensor
+                                  sizeTensor:(MPSGraphTensor * _Nonnull) size
+                         nearestRoundingMode:(MPSGraphResizeNearestRoundingMode) nearestRoundingMode
+                                centerResult:(BOOL) centerResult
+                                alignCorners:(BOOL) alignCorners
+                                      layout:(MPSGraphTensorNamedDataLayout) layout
+                                        name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeNearestWithTensor:(MPSGraphTensor * _Nonnull) imagesTensor
+                                  sizeTensor:(MPSGraphTensor * _Nonnull) size
+                           scaleOffsetTensor:(MPSGraphTensor * _Nonnull) scaleOffset
+                         nearestRoundingMode:(MPSGraphResizeNearestRoundingMode) nearestRoundingMode
+                                      layout:(MPSGraphTensorNamedDataLayout) layout
+                                        name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeBilinearWithTensor:(MPSGraphTensor * _Nonnull) imagesTensor
+                                   sizeTensor:(MPSGraphTensor * _Nonnull) size
+                                 centerResult:(BOOL) centerResult
+                                 alignCorners:(BOOL) alignCorners
+                                       layout:(MPSGraphTensorNamedDataLayout) layout
+                                         name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeBilinearWithTensor:(MPSGraphTensor * _Nonnull) imagesTensor
+                                   sizeTensor:(MPSGraphTensor * _Nonnull) size
+                            scaleOffsetTensor:(MPSGraphTensor * _Nonnull) scaleOffset
+                                       layout:(MPSGraphTensorNamedDataLayout) layout
+                                         name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeNearestWithGradientTensor:(MPSGraphTensor * _Nonnull) gradient
+                                               input:(MPSGraphTensor * _Nonnull) input
+                                 nearestRoundingMode:(MPSGraphResizeNearestRoundingMode) nearestRoundingMode
+                                        centerResult:(BOOL) centerResult
+                                        alignCorners:(BOOL) alignCorners
+                                              layout:(MPSGraphTensorNamedDataLayout) layout
+                                                name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeNearestWithGradientTensor:(MPSGraphTensor * _Nonnull) gradient
+                                               input:(MPSGraphTensor * _Nonnull) input
+                                   scaleOffsetTensor:(MPSGraphTensor * _Nonnull) scaleOffset
+                                 nearestRoundingMode:(MPSGraphResizeNearestRoundingMode) nearestRoundingMode
+                                              layout:(MPSGraphTensorNamedDataLayout) layout
+                                                name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeBilinearWithGradientTensor:(MPSGraphTensor * _Nonnull) gradient
+                                                input:(MPSGraphTensor * _Nonnull) input
+                                         centerResult:(BOOL) centerResult
+                                         alignCorners:(BOOL) alignCorners
+                                               layout:(MPSGraphTensorNamedDataLayout) layout
+                                                 name:(NSString * _Nullable) name;
+
+- (MPSGraphTensor * _Nonnull) resizeBilinearWithGradientTensor:(MPSGraphTensor * _Nonnull) gradient
+                                                input:(MPSGraphTensor * _Nonnull) input
+                                    scaleOffsetTensor:(MPSGraphTensor * _Nonnull) scaleOffset
+                                               layout:(MPSGraphTensorNamedDataLayout) layout
+                                                 name:(NSString * _Nullable) name;
 @end

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -5,7 +5,6 @@
 #include <ATen/Utils.h>
 #include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/TensorFactory.h>
-#include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <c10/core/ScalarType.h>
 #include <torch/library.h>
 #include <unordered_map>

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -5,6 +5,7 @@
 #include <ATen/Utils.h>
 #include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/TensorFactory.h>
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <c10/core/ScalarType.h>
 #include <torch/library.h>
 #include <unordered_map>

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -3,9 +3,9 @@
 #include <ATen/native/Distributions.h>
 #include <ATen/native/DistributionTemplates.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/mps/MPSGeneratorImpl.h>
 #include <ATen/native/TensorFactories.h>
-#include <ATen/native/mps/MPSGraphVenturaOps.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -5,6 +5,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/mps/MPSGeneratorImpl.h>
 #include <ATen/native/TensorFactories.h>
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/mps/operations/Inverse.mm
+++ b/aten/src/ATen/native/mps/operations/Inverse.mm
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <torch/library.h>
 #include <c10/util/Optional.h>
 


### PR DESCRIPTION
Fix build errors (`WERROR=`1) caused by unrecognized macOS Ventura selectors. 
