### PR TITLE
Remove unused pragma

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -307,15 +307,9 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraphTensor *maskTensor = [mpsGraph castTensor:inputNotEqualToZeroTensor
                                                      toType:MPSDataTypeInt32
                                                        name:@"castToInt32"];
-
-          C10_CLANG_DIAGNOSTIC_PUSH()
-          #if C10_CLANG_HAS_WARNING("-Wobjc-method-access")
-          C10_CLANG_DIAGNOSTIC_IGNORE("-Wobjc-method-access")
-          #endif
           MPSGraphTensor *indicesTensor = [mpsGraph cumulativeSumWithTensor:maskTensor
                                                                        axis:0
                                                                        name:nil];
-          C10_CLANG_DIAGNOSTIC_POP()
           MPSGraphTensor *indicesMinusOneTensor = [mpsGraph subtractionWithPrimaryTensor:indicesTensor
                                                                         secondaryTensor:oneTensor
                                                                                    name:nil];


### PR DESCRIPTION
Remove unused pragma - the missing selector is already handled by `MPSGraphVenturaOps.h`