### PR TITLE
Fix and unblock TestConsistency for median

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1847,11 +1847,31 @@ Tensor median_mps(const Tensor& input_t) {
             MPSGraphTensor * reshapedTensor = [mpsGraph reshapeTensor:inputTensor
                                                             withShape:@[@-1]
                                                                   name:nil];
+            MPSDataType dataType = [inputTensor dataType];
+            // #issue 104398441 sortWithTensor only supports following types, cast if necessary
+            if (dataType != MPSDataTypeInt32 &&
+                dataType != MPSDataTypeFloat32 &&
+                dataType != MPSDataTypeFloat16) {
+                dataType = (dataType & MPSDataTypeFloatBit) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
+                reshapedTensor = [mpsGraph castTensor:reshapedTensor
+                                        toType:dataType
+                                          name:@"castReshapedTensor"];
+            }
+
             MPSGraphTensor * sortedTensor = [mpsGraph
                                                   sortWithTensor:reshapedTensor
                                                   axis:((NSUInteger) (int)0)
                                                   name:nil];
 
+            // Cast back
+            dataType = [inputTensor dataType];
+            if (dataType != MPSDataTypeInt32 &&
+                dataType != MPSDataTypeFloat32 &&
+                dataType != MPSDataTypeFloat16) {
+                sortedTensor = [mpsGraph castTensor:sortedTensor
+                                        toType:dataType
+                                          name:@"castSortedTensor"];
+            }
             outputTensor = [mpsGraph sliceTensor:sortedTensor
                                                         dimension:0
                                                         start:((NSUInteger) (int)((num_in_elements+1)/2 ) - 1)
@@ -1934,7 +1954,7 @@ void median_out_mps
     auto stream = at::mps::getCurrentMPSStream();
 
     @autoreleasepool {
-        string key = func_name + ":" + to_string(dim_) + ":" + native_mps::getTensorsStringKey(input_t);
+        string key = func_name + ":" + to_string(dim_) + ":" + native_mps::getTensorsStringKey(input_t) + ":" + native_mps::getTensorsStringKey(indices_t);
         CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
         if(!cachedGraph) {
@@ -1948,8 +1968,20 @@ void median_out_mps
 
               MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
               MPSGraphTensor* outputTensor = nil;
+              MPSGraphTensor* castInputTensor = inputTensor;
+              MPSDataType dataType = native_mps::getMPSDataType(input_t.scalar_type());
+              // #issue 104398441 sortWithTensor only supports following types, cast if necessary
+              if (dataType != MPSDataTypeInt32 &&
+                  dataType != MPSDataTypeFloat32 &&
+                  dataType != MPSDataTypeFloat16) {
+                  dataType = (dataType & MPSDataTypeFloatBit) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
+                  castInputTensor = [mpsGraph castTensor:inputTensor
+                                          toType:dataType
+                                            name:@"castInputTensor"];
+              }
+
               MPSGraphTensor * sortedTensor = [mpsGraph
-                                                  sortWithTensor:inputTensor
+                                                  sortWithTensor:castInputTensor
                                                   axis:((NSUInteger) (int)dim_)
                                                   name:nil];
 
@@ -1959,7 +1991,7 @@ void median_out_mps
                                                         length:1
                                                         name:nil];
               MPSGraphTensor* argreduceOutTensor = nil;
-                argreduceOutTensor = [mpsGraph argSortWithTensor:inputTensor
+                argreduceOutTensor = [mpsGraph argSortWithTensor:castInputTensor
                                                                         axis:(NSInteger)dim_
                                                                         name:@"argmax_out"];
               MPSGraphTensor* argOutputTensor = [mpsGraph sliceTensor:argreduceOutTensor
@@ -1967,6 +1999,15 @@ void median_out_mps
                                                         start:((NSUInteger) (int)((dim_total_elements+1)/2 ) - 1)
                                                         length:1
                                                         name:nil];
+              // Cast back
+              dataType = native_mps::getMPSDataType(input_t.scalar_type());
+              if (dataType != MPSDataTypeInt32 &&
+                  dataType != MPSDataTypeFloat32 &&
+                  dataType != MPSDataTypeFloat16) {
+                  argreduceOutTensor = [mpsGraph castTensor:argreduceOutTensor
+                                          toType:dataType
+                                            name:@"castargargreduceOutTensor"];
+              }
 
               newCachedGraph->inputTensor_ = inputTensor;
               newCachedGraph->outputTensor_ = outputTensor;
@@ -2038,7 +2079,7 @@ TORCH_API ::std::tuple<at::Tensor &,at::Tensor &> median_out_mps
     int64_t num_input_dims = input_shape.size();
     NSMutableArray<NSNumber*> *apparent_out_shape = nil;
     // Use this if keepdim is false
-    int64_t num_output_dims = num_input_dims - 1;
+    int64_t num_output_dims = num_input_dims - 1 < 0 ? 0 : num_input_dims - 1;
 
     std::vector<int64_t> vec_apparent_out_shape(num_input_dims);
     std::vector<int64_t> vec_out_shape(num_output_dims);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1863,15 +1863,6 @@ Tensor median_mps(const Tensor& input_t) {
                                                   axis:((NSUInteger) (int)0)
                                                   name:nil];
 
-            // Cast back
-            dataType = [inputTensor dataType];
-            if (dataType != MPSDataTypeInt32 &&
-                dataType != MPSDataTypeFloat32 &&
-                dataType != MPSDataTypeFloat16) {
-                sortedTensor = [mpsGraph castTensor:sortedTensor
-                                        toType:dataType
-                                          name:@"castSortedTensor"];
-            }
             outputTensor = [mpsGraph sliceTensor:sortedTensor
                                                         dimension:0
                                                         start:((NSUInteger) (int)((num_in_elements+1)/2 ) - 1)

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1999,13 +1999,11 @@ void median_out_mps
                                                         start:((NSUInteger) (int)((dim_total_elements+1)/2 ) - 1)
                                                         length:1
                                                         name:nil];
-              // Cast back
+
               dataType = native_mps::getMPSDataType(input_t.scalar_type());
-              if (dataType != MPSDataTypeInt32 &&
-                  dataType != MPSDataTypeFloat32 &&
-                  dataType != MPSDataTypeFloat16) {
+              if (dataType != MPSDataTypeInt64) {
                   argreduceOutTensor = [mpsGraph castTensor:argreduceOutTensor
-                                          toType:dataType
+                                          toType:MPSDataTypeInt64
                                             name:@"castargargreduceOutTensor"];
               }
 

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -2000,13 +2000,6 @@ void median_out_mps
                                                         length:1
                                                         name:nil];
 
-              dataType = native_mps::getMPSDataType(input_t.scalar_type());
-              if (dataType != MPSDataTypeInt64) {
-                  argreduceOutTensor = [mpsGraph castTensor:argreduceOutTensor
-                                          toType:MPSDataTypeInt64
-                                            name:@"castargargreduceOutTensor"];
-              }
-
               newCachedGraph->inputTensor_ = inputTensor;
               newCachedGraph->outputTensor_ = outputTensor;
               newCachedGraph->indicesTensor_ = argOutputTensor;

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -56,7 +56,7 @@ NSArray<MPSGraphTensor*> *buildUniqueGraph(const Tensor& self, UniqueCachedGraph
     return @[resultTensor, inverseIndicesTensor, countTensor, lengthTensor];
   }
 
-  // Sort only supports following types, cast if necessary
+  // #issue 104398441 sortWithTensor only supports following types, cast if necessary
   if (dataType != MPSDataTypeInt32 &&
       dataType != MPSDataTypeFloat32 &&
       dataType != MPSDataTypeFloat16) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9380,7 +9380,6 @@ class TestConsistency(TestCase):
     BLOCKLIST = {
         # Functions that hard crash
         'nn.functional.softplus': [torch.float32],
-        'nonzero': [torch.bool, torch.uint8, torch.float16],
         'sgn': [torch.bool],
         'linalg.inv': [torch.float32],
         'linalg.inv_ex': [torch.float32],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2237,6 +2237,17 @@ class TestMPS(TestCase):
     #     helper((2, 8, 4, 5), torch.int16)
     #     helper((2, 8, 4, 5), torch.int32)
 
+    def test_median_int16(self):
+        def helper(shape, dtype):
+            cpu_x = torch.randint(-9999, 9999, shape, device='cpu', dtype=dtype)
+            x = cpu_x.detach().clone().to('mps')
+
+            median_result = torch.median(x)
+            median_result_cpu = torch.median(cpu_x)
+            self.assertEqual(median_result, median_result_cpu)
+
+        helper((2, 8, 4, 5), torch.int16)
+
 class TestLogical(TestCase):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):
         return torch.tensor(x, device=device, dtype=dtype, requires_grad=requires_grad)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9369,7 +9369,7 @@ class TestConsistency(TestCase):
     BLOCKLIST = {
         # Functions that hard crash
         'nn.functional.softplus': [torch.float32],
-        'median': [torch.float32, torch.int16, torch.int32, torch.uint8, torch.int16],
+        'nonzero': [torch.bool, torch.uint8, torch.float16],
         'sgn': [torch.bool],
         'linalg.inv': [torch.float32],
         'linalg.inv_ex': [torch.float32],


### PR DESCRIPTION
- fix num_output_dims calculation
- fix median_out_mps key
- cast tensor sent to sortWithTensor and argSortWithTensor, and cast back for output
- note down same issue for unique
- unblock median from blocklist