### PR TITLE
Fix floor_divide

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -176,8 +176,21 @@ void div_mode_template(const Tensor& self, const Tensor& other,
                        c10::optional<c10::string_view> rounding_mode,
                        const Tensor& output, const string op_name)
 {
+  if(rounding_mode.has_value() && *rounding_mode == "floor"){
+    TORCH_CHECK(self.scalar_type() != ScalarType::Long,
+                "MPS: does not support floor_divide op with int64 input");
+  }
   BinaryOpBlock div_mode_op_block = ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) {
     MPSGraph* mpsGraph = cachedGraph->graph();
+    bool isFloatInput = ([primaryCastTensor dataType] & MPSDataTypeFloatBit) != 0;
+    if(!isFloatInput && rounding_mode.has_value() && *rounding_mode == "floor") {
+      primaryCastTensor = [mpsGraph castTensor:primaryCastTensor
+                                        toType:MPSDataTypeFloat32
+                                          name:@"primaryCastTensor"];
+      secondaryCastTensor = [mpsGraph castTensor:secondaryCastTensor
+                                          toType:MPSDataTypeFloat32
+                                            name:@"secondaryCastTensor"];
+    }
     MPSGraphTensor* divTensor =  [mpsGraph divisionWithPrimaryTensor:primaryCastTensor
                                                      secondaryTensor:secondaryCastTensor
                                                                 name:nil];

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9363,7 +9363,6 @@ class TestConsistency(TestCase):
 
         # Functions with correctness issues
         'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
-        'divfloor_rounding': [torch.int16, torch.int32, torch.int64],
         'norm': [torch.float16],
         'nn.functional.feature_alpha_dropoutwith_train': [torch.float32],
         'cumulative_trapezoid': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
@@ -9373,7 +9372,6 @@ class TestConsistency(TestCase):
         'normalnumber_mean': [torch.float16, torch.float32],
         'new_empty_strided': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'multinomial': [torch.float32],
-        'floor_divide': [torch.int16, torch.int32, torch.int64],
         'dist': [torch.float16],
 
         # failure due to issue: atan2() may generate NAN in output with

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4029,7 +4029,7 @@ class TestNLLLoss(TestCase):
     def test_divmode(self):
         def helper(shape, rounding_mode):
             for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
-                if (rounding_mode != None and "floor" in rounding_mode and dtype == torch.int64) is not None:
+                if (rounding_mode != None and "floor" in rounding_mode and dtype == torch.int64) is None:
                     cpu_x = None
                     cpu_y = None
                     if (dtype in [torch.float32, torch.float16]):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4029,7 +4029,7 @@ class TestNLLLoss(TestCase):
     def test_divmode(self):
         def helper(shape, rounding_mode):
             for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
-                if not (rounding_mode != None and "floor" in rounding_mode and dtype == torch.int64):
+                if (rounding_mode != None and "floor" in rounding_mode and dtype == torch.int64) is not None:
                     cpu_x = None
                     cpu_y = None
                     if (dtype in [torch.float32, torch.float16]):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2221,6 +2221,21 @@ class TestMPS(TestCase):
 
         helper((2, 8, 4, 5))
 
+    # # Failures due to precision issues, enable after resolving from mps
+    # def test_div_floor_int(self):
+    #     def helper(shape, dtype):
+    #         cpu_x = torch.randint(-9999, -1,shape, device='cpu', dtype=dtype)
+    #         x = cpu_x.detach().clone().to('mps')
+
+    #         cpu_y = torch.randint(1, 9999, shape, device='cpu', dtype=dtype)
+    #         y = cpu_y.detach().clone().to('mps')
+
+    #         div_result = torch.div(x, y,rounding_mode='floor')
+    #         div_result_cpu = torch.div(cpu_x, cpu_y, rounding_mode='floor')
+    #         self.assertEqual(div_result, div_result_cpu)
+
+    #     helper((2, 8, 4, 5), torch.int16)
+    #     helper((2, 8, 4, 5), torch.int32)
 
 class TestLogical(TestCase):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):
@@ -8283,22 +8298,6 @@ class TestRNNMPS(TestCase):
         self.assertEqual(cpu_output, mps_output)
         self.assertEqual(cpu_input_grad, mps_input_grad)
         self.assertEqual(cpu_weight_grad, mps_weight_grad)
-
-    # # Failures due to precision issues, enable after resolving from mps
-    # def test_div_floor_int(self):
-    #     def helper(shape, dtype):
-    #         cpu_x = torch.randint(-9999, -1,shape, device='cpu', dtype=dtype)
-    #         x = cpu_x.detach().clone().to('mps')
-
-    #         cpu_y = torch.randint(1, 9999, shape, device='cpu', dtype=dtype)
-    #         y = cpu_y.detach().clone().to('mps')
-
-    #         div_result = torch.div(x, y,rounding_mode='floor')
-    #         div_result_cpu = torch.div(cpu_x, cpu_y, rounding_mode='floor')
-    #         self.assertEqual(div_result, div_result_cpu)
-
-    #     helper((2, 8, 4, 5), torch.int16)
-    #     helper((2, 8, 4, 5), torch.int32)
 
 class TestFallbackWarning(TestCase):
     # TODO: Remove once test_testing.py is running on MPS devices

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4029,7 +4029,7 @@ class TestNLLLoss(TestCase):
     def test_divmode(self):
         def helper(shape, rounding_mode):
             for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
-                if (rounding_mode != None and "floor" in rounding_mode and dtype == torch.int64) is None:
+                if (rounding_mode is not None and "floor" in rounding_mode and dtype == torch.int64) is False:
                     cpu_x = None
                     cpu_y = None
                     if (dtype in [torch.float32, torch.float16]):


### PR DESCRIPTION
- report error for int64
- for int16,int32 cast tensor to float, divide than floor
- unblock floor_divide and divfloor_rounding from testing
