### PR TITLE
Fix is_mps_available() regression on non-MPS devices

### DIFF
--- a/torch/backends/mps/__init__.py
+++ b/torch/backends/mps/__init__.py
@@ -11,4 +11,6 @@ def is_built() -> bool:
 @_lru_cache()
 def is_available() -> bool:
     r"""Returns a bool indicating if MPS is currently available."""
+    if not hasattr(torch._C, '_is_mps_available'):
+        return False
     return torch._C._is_mps_available()

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -33,7 +33,7 @@ static PyObject* MPSModule_initExtension(PyObject* self, PyObject* noargs) {
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   auto gen = at::mps::detail::getDefaultMPSGenerator();
   auto default_mps_generator = (THPGenerator*)THPGenerator_initDefaultGenerator(gen);
-  set_module_attr("default_generator", (PyObject*) default_mps_generator);
+  set_module_attr("default_mps_generator", (PyObject*) default_mps_generator);
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -9,7 +9,7 @@ import torch._C
 
 _initialized = False
 _initialization_lock = threading.Lock()
-default_generator: torch._C.Generator = ()  # type: ignore[assignment]
+default_mps_generator: torch._C.Generator = None  # type: ignore[assignment]
 
 def init():
     r"""Initialize PyTorch's MPS state.
@@ -32,6 +32,8 @@ def _lazy_init():
 @lru_cache()
 def is_available() -> bool:
     r"""Returns a bool indicating if MPS is currently available."""
+    if not hasattr(torch._C, '_is_mps_available'):
+        return False
     return torch._C._is_mps_available()
 
 def synchronize() -> None:
@@ -43,7 +45,7 @@ def synchronize() -> None:
 def get_rng_state() -> Tensor:
     r"""Returns the random number generator state as a ByteTensor."""
     _lazy_init()
-    return default_generator.get_state()
+    return default_mps_generator.get_state()
 
 def set_rng_state(new_state: Tensor) -> None:
     r"""Sets the random number generator state.
@@ -52,7 +54,7 @@ def set_rng_state(new_state: Tensor) -> None:
     """
     _lazy_init()
     new_state_copy = new_state.clone(memory_format=torch.contiguous_format)
-    default_generator.set_state(new_state_copy)
+    default_mps_generator.set_state(new_state_copy)
 
 def manual_seed(seed: int) -> None:
     r"""Sets the seed for generating random numbers
@@ -63,17 +65,17 @@ def manual_seed(seed: int) -> None:
         return
     _lazy_init()
     seed = int(seed)
-    default_generator.manual_seed(seed)
+    default_mps_generator.manual_seed(seed)
 
 def seed() -> None:
     r"""Sets the seed for generating random numbers to a random number."""
     _lazy_init()
-    default_generator.seed()
+    default_mps_generator.seed()
 
 def is_initialized():
     r"""Returns whether PyTorch's MPS state has been initialized."""
     return _initialized
 
 __all__ = [
-    'default_generator', 'get_rng_state', 'is_available', 'manual_seed',
+    'default_mps_generator', 'get_rng_state', 'is_available', 'manual_seed',
     'seed', 'set_rng_state', 'synchronize', 'init', 'is_initialized']


### PR DESCRIPTION
- This patch fixes a regression caused by recent MPS module interface. Since we now compile `torch._C._is_mps_available()` only if `USE_MPS` is defined, then it may cause failures on CUDA (and other devices where `USE_MPS` is not defined), if we upstream. So, this patch checks if `is_mps_available` is implemented first and then calls it.
- Also use the unique name `default_mps_generator` to avoid conflicts with CPU default generator

