### PR TITLE
Revert "Revert "Added zero check to inverse op, resolving crash seen …

### DIFF
--- a/aten/src/ATen/native/mps/operations/Inverse.mm
+++ b/aten/src/ATen/native/mps/operations/Inverse.mm
@@ -24,6 +24,10 @@ TORCH_IMPL_FUNC(linalg_inv_ex_out_mps)(const Tensor& A, bool check_errors, const
     MPSStream* stream = getCurrentMPSStream();
     info.zero_();
 
+    if (A.numel() == 0) {
+        return;
+    }
+
     struct CachedGraph : public MPSCachedGraph
     {
         CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9409,8 +9409,6 @@ class TestConsistency(TestCase):
     BLOCKLIST = {
         # Functions that hard crash
         'sgn': [torch.bool],
-        'linalg.inv': [torch.float32],
-        'linalg.inv_ex': [torch.float32],
         'linalg.matrix_power': [torch.float32],
         'resize_': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'resize_as_': [torch.float16, torch.float32],


### PR DESCRIPTION
…in inverse & matrix_pow tests (#236)""

This reverts commit d88dc8bf3a95bc5fe8adc24e44386065699210d2.

Segfaults seen during testing may have been device-specific. Creating PR to test using CI

Fixes #ISSUE_NUMBER
