### PR TITLE
Fix crashes in several backward ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -417,6 +417,9 @@ TORCH_IMPL_FUNC(sigmoid_backward_out_mps)(
   using namespace mps;
   TORCH_CHECK(grad_input.is_mps());
 
+  if (grad_output.numel() == 0) {
+    return;
+  }
   struct CachedGraph : public MPSCachedGraph
   {
     CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
@@ -493,6 +496,9 @@ TORCH_IMPL_FUNC(tanh_backward_out_mps)(
   using namespace mps;
   TORCH_CHECK(grad_input.is_mps());
 
+  if (grad_output.numel() == 0) {
+    return;
+  }
   struct CachedGraph : public MPSCachedGraph
   {
     CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
@@ -1770,6 +1776,9 @@ std::tuple<Tensor, Tensor> prelu_backward_mps(const Tensor& grad_output, const T
     Tensor grad_input = at::empty_like(self, self.suggest_memory_format());
     Tensor weight_grad = at::empty_like(weight_, at::MemoryFormat::Contiguous);
 
+    if (grad_output.numel() == 0) {
+      return std::tuple<Tensor, Tensor>{grad_input, weight_grad};
+    }
     TORCH_CHECK(
       weight_.dim() == 1 || weight_.dim() == 0,
       "prelu: Expected `weight` to be a scalar or 1D tensor, but got ndim = ", weight_.dim()

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -740,6 +740,10 @@ Tensor& index_select_out_mps(const Tensor & self,
 
 Tensor & masked_fill__mps(Tensor& self, const Tensor & mask, const Scalar& value) {
   using namespace mps;
+
+  if (self.numel() == 0) {
+    return self;
+  }
   TORCH_CHECK(self.device() == mask.device(), "expected self and mask to be on the same device, but got mask on ",
     mask.device(), " and self on ", self.device());
   TORCH_CHECK(mask.scalar_type() == kByte || mask.scalar_type() == kBool,

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -169,6 +169,9 @@ Tensor _mps_linear_backward_input(
                                         c10::nullopt,
                                         grad_output.suggest_memory_format());
   TORCH_CHECK(output.is_mps());
+  if (grad_output.numel() == 0) {
+    return output;
+  }
 
   MPSGraphCache *cache_ = MPSGraphCache::getInstance();
 
@@ -263,6 +266,11 @@ std::tuple<Tensor, Tensor> _mps_linear_backward_weights(
   TORCH_CHECK(output.is_mps());
   TORCH_CHECK(bias.is_mps());
 
+  if (grad_output.numel() == 0) {
+    output.zero_();
+    bias.zero_();
+    return std::tuple<Tensor, Tensor>{ output, bias };
+  }
   MPSGraphCache *cache_ = MPSGraphCache::getInstance();
 
   MPSStream *stream= getCurrentMPSStream();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9755,19 +9755,8 @@ class TestConsistency(TestCase):
         'unfold': ['f16', 'f32'],
         'trace': ['f32'],
 
-        # Hard crash
-        'linalg.norm': ['f16'],
-        'linalg.norm_subgradients': ['f16'],
-        'max': ['f16', 'f32'],
-        'maximum': ['f16', 'f32'],
-        'min': ['f16', 'f32'],
-        'minimum': ['f16', 'f32'],
-        'nn.functional.linear': ['f32'],
-        'nn.functional.prelu': ['f32'],
-        'nn.functional.tanhshrink': ['f32'],
-        'sigmoid': ['f32'],
-
         # Correctness issues
+        'nn.functional.prelu': ['f32'],
         'nn.functional.conv_transpose2d': ['f32'],
         'atanh': ['f32'],
         'div': ['f16'],


### PR DESCRIPTION
- This should fix the hard crashes reported in BLOCKLIST_OP_GRAD such as sigmoid, tanh, masked_fill, linear, prelu, etc.
- The prelu now fails with correctness issues so I kept it in the blocklist