### PR TITLE
Enable test_nn and test_ops to run on mps

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1449,7 +1449,6 @@ class TestCompositeCompliance(TestCase):
     )
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_operator(self, device, dtype, op):
-        print(op.name)
         msg = self.get_mps_error_msg(device, dtype, op)
         if msg is not None:
             self.skipTest(msg)
@@ -1467,7 +1466,6 @@ class TestCompositeCompliance(TestCase):
     )
     @ops([op for op in op_db if op.supports_autograd], allowed_dtypes=(torch.float,))
     def test_backward(self, device, dtype, op):
-        print(op.name)
         msg = self.get_mps_error_msg(device, dtype, op)
         if msg is not None:
             self.skipTest(msg)
@@ -1489,7 +1487,6 @@ class TestCompositeCompliance(TestCase):
     )
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_forward_ad(self, device, dtype, op):
-        print(op.name)
         msg = self.get_mps_error_msg(device, dtype, op)
         if msg is not None:
             self.skipTest(msg)


### PR DESCRIPTION
Enable test_nn and test_ops to run on mps without segfaulting

Important failures listed below (big difference in atol and rtol diff).

- **test_nn.py** failures:
```
test_rnn_retain_variables_mps_float32
test_nonlinearity_propagate_nan_mps
test_nll_loss_total_weight_is_zero_mps
test_nll_loss_all_ignored_mps
test_cross_entropy_label_smoothing_weight_ignore_indices_mps
test_cross_entropy_label_smoothing_consistent_index_target_and_probs_mps
```
- **test_ops.py** failures:
```
test_backward_repeat_interleave_mps_float32
test_backward_nn_functional_upsample_nearest_mps_float32
test_backward_nn_functional_bilinear_mps_float32
test_backward_gradient_mps_float32
test_backward_gather_mps_float32
test_operator_trapezoid_mps_float32
test_operator_nn_functional_avg_pool2d_mps_float32
test_operator_gradient_mps_float32
test_forward_ad_trapz_mps_float32
test_forward_ad_trapezoid_mps_float32
test_forward_ad_svd_mps_float32
test_forward_ad_nn_functional_upsample_nearest_mps_float32
test_pointwise_ops_to_mps_float32
test_forward_ad_linalg_svd_mps_float32
test_operator_trapz_mps_float32
```