### PR TITLE
Fix correctness issues in solve_triangular()

### DIFF
--- a/aten/src/ATen/native/mps/operations/TriangularOps.mm
+++ b/aten/src/ATen/native/mps/operations/TriangularOps.mm
@@ -20,6 +20,10 @@ TORCH_IMPL_FUNC(triu_mps_out)
  const Tensor &output) {
 
   using namespace mps;
+
+  if (self.numel() == 0) {
+    return;
+  }
   MPSStream* stream = getCurrentMPSStream();
 
   // Derive from MPSCachedGraph
@@ -99,6 +103,10 @@ TORCH_IMPL_FUNC(tril_mps_out)
  const Tensor &output) {
 
   using namespace mps;
+
+  if (self.numel() == 0) {
+    return;
+  }
   MPSStream* stream = getCurrentMPSStream();
 
   // Derive from MPSCachedGraph

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9825,9 +9825,7 @@ class TestConsistency(TestCase):
         'nn.functional.conv_transpose2d': ['f32'],
         'atanh': ['f32'],
         'div': ['f16'],
-        'linalg.solve_triangular': ['f32'],
         'nn.functional.bilinear': ['f32'],
-        'triangular_solve': ['f32'],
         'nn.functional.embedding': ['f16'],
 
         # Unsupported dtype


### PR DESCRIPTION
- make input tensors contiguous before computing solve_triangular()
- fix the crashes in triu and tril ops due to missing numel()==0 checks
- zero out result of bmm() when numel()==0 check is true (otherwise fails solve_triangular_backward tests)
