### PR TITLE
Moved unique to expected failures due to dim argument not supported

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10396,7 +10396,7 @@ class TestConsistency(TestCaseMPS):
         'signal.windows.kaiser': [torch.float16],
         'stft': [torch.float32],
         'tensordot': [torch.int16, torch.int32, torch.int64, torch.uint8],
-        'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
+        #'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'zeros_like': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],  
         'bincount': [torch.int16, torch.int32, torch.int64, torch.uint8],
     }
@@ -10595,6 +10595,8 @@ class TestConsistency(TestCaseMPS):
                 elif op.name == "norm" and dtype == torch.float16:
                     atol = 7e-4
                     rtol = 1.5e-3
+                elif op.name == "unique" and cpu_kwargs["sorted"] == False:
+                    continue
                 else:
                     atol = None
                     rtol = None

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10060,7 +10060,6 @@ class TestConsistency(TestCaseMPS):
         'topk': [torch.int16, torch.int32, torch.int64, torch.uint8],
 
         # Functions with correctness issues
-        'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'nn.functional.feature_alpha_dropoutwith_train': [torch.float32],
         'as_stridedpartial_views': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'trace': [torch.int64],
@@ -10397,7 +10396,8 @@ class TestConsistency(TestCaseMPS):
         'signal.windows.kaiser': [torch.float16],
         'stft': [torch.float32],
         'tensordot': [torch.int16, torch.int32, torch.int64, torch.uint8],
-        'zeros_like': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
+        'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
+        'zeros_like': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],  
         'bincount': [torch.int16, torch.int32, torch.int64, torch.uint8],
     }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10310,6 +10310,7 @@ class TestConsistency(TestCaseMPS):
         'symeig': [torch.float32],
         'take': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'to_sparse': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
+        'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'var_mean': [torch.float16, torch.float32],
         'var_meanunbiased': [torch.float16, torch.float32],
         'vdot': [torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
@@ -10396,7 +10397,6 @@ class TestConsistency(TestCaseMPS):
         'signal.windows.kaiser': [torch.float16],
         'stft': [torch.float32],
         'tensordot': [torch.int16, torch.int32, torch.int64, torch.uint8],
-        #'unique': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'zeros_like': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],  
         'bincount': [torch.int16, torch.int32, torch.int64, torch.uint8],
     }


### PR DESCRIPTION
Unique was listed as having a correctness failure, but this was only because it always sorts the output and CPU does not. Moving to expected failures, as MPSGraph does not support dim argument