### PR TITLE
Downstream scatter fix for bool from upstream

### DIFF
--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -190,7 +190,7 @@ void scatter_mps_general
     TORCH_CHECK(reduce != "mean", "Scatter reduce mean mode not yet supported in MPS")
 
     MPSDataType src_type = getMPSDataType(src.scalar_type());
-    if (reduce != "set" || self.scalar_type() == ScalarType::Byte) {
+    if (reduce != "set" || src_type == MPSDataTypeUInt8 || src_type == MPSDataTypeBool) {
       src_type = isFloatingType(src.scalar_type()) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
       needsCast = true;
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10464,7 +10464,6 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.triplet_margin_loss': [torch.uint8],
         'nn.functional.triplet_margin_with_distance_loss': [torch.uint8],
         'nn.functional.upsample_nearest': [torch.float32],
-        'scatter': [torch.bool],
         'sum_to_size': [torch.float16],
         'transpose': [torch.int64],
 


### PR DESCRIPTION
Fixes TestConsistency.scatter on macOS 12