### PR TITLE
Fix remainder op for integral dtypes

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -355,9 +355,6 @@ Tensor& floor_divide_mps_(Tensor& self, const Tensor& other) {
 }
 
 TORCH_IMPL_FUNC(remainder_out_mps) (const Tensor& self, const Tensor& other, const Tensor& output) {
-  TORCH_CHECK(self.scalar_type() != kLong && other.scalar_type() != kLong,
-              "MPS: does not support remainder op with int64 input");
-
   mps::div_mode_template(self, other, "floor", output, "remainder_out_mps");
 }
 

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -205,7 +205,16 @@ void div_mode_template(const Tensor& self, const Tensor& other,
     } else if (*rounding_mode == "trunc") {
       return trunc_tensor(mpsGraph, divTensor);
     } else if (*rounding_mode == "floor") {
-      return [mpsGraph floorWithTensor:divTensor name:nil];
+      MPSGraphTensor* floorTensor = [mpsGraph floorWithTensor:divTensor name:nil];
+      if (op_name == "remainder_out_mps") {
+        auto mulTensor = [mpsGraph multiplicationWithPrimaryTensor:floorTensor
+                                                   secondaryTensor:secondaryCastTensor
+                                                              name:nil];
+        return [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor
+                                      secondaryTensor:mulTensor
+                                                 name:nil];
+      }
+      return floorTensor;
     }
     assert(0 && "Invalid rounding mode\n");
     return nullptr;
@@ -346,29 +355,10 @@ Tensor& floor_divide_mps_(Tensor& self, const Tensor& other) {
 }
 
 TORCH_IMPL_FUNC(remainder_out_mps) (const Tensor& self, const Tensor& other, const Tensor& output) {
-  // torch.remainder(a, b) == a - a.div(b, rounding_mode="floor") * b
-  mps::BinaryOpBlock remainder_op_block = ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) {
-    MPSGraph* mpsGraph = cachedGraph->graph();
-    // Rounding is a no-op for integral types, and also a reasonable workaround
-    // For MPSGraph bug on Apple Silicon, that throws `Function floorOp_i64 was not found in the library`
-    // See https://github.com/pytorch/pytorch/issues/84995
+  TORCH_CHECK(self.scalar_type() != kLong && other.scalar_type() != kLong,
+              "MPS: does not support remainder op with int64 input");
 
-    auto divTensor =  [mpsGraph divisionWithPrimaryTensor:primaryCastTensor
-                                          secondaryTensor:secondaryCastTensor
-                                                     name:nil];
-    bool isFloatOutput = ([divTensor dataType] & MPSDataTypeFloatBit) != 0;
-    if (isFloatOutput) {
-      divTensor = [mpsGraph floorWithTensor:divTensor name:nil];
-    }
-
-    auto mulTensor = [mpsGraph multiplicationWithPrimaryTensor:divTensor
-                                               secondaryTensor:secondaryCastTensor
-                                                          name:nil];
-    return [mpsGraph subtractionWithPrimaryTensor:primaryCastTensor
-                                       secondaryTensor:mulTensor
-                                           name: nil];
-    };
-  mps::binaryOpTensor(self, other, Scalar(1.0), output, "remainder_out_mps", remainder_op_block);
+  mps::div_mode_template(self, other, "floor", output, "remainder_out_mps");
 }
 
 TORCH_IMPL_FUNC(logaddexp_out_mps) (const Tensor& self, const Tensor& other, const Tensor& output)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9207,7 +9207,7 @@
   device_check: NoCheck   # TensorIterator
   variants: function
   dispatch:
-    CPU, CUDA: remainder
+    CPU, CUDA, MPS: remainder
   autogen: remainder.Scalar_Tensor_out
   tags: pointwise
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4283,12 +4283,16 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 8, 4, 5))
 
     def test_remainder(self):
-        res_cpu = torch.remainder(torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="cpu"), torch.tensor(2, device="cpu", dtype=torch.int32))
-        res_mps = torch.remainder(torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="mps"), torch.tensor(2, device="mps", dtype=torch.int32))
+        res_cpu = torch.remainder(
+            torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="cpu"), torch.tensor(2, device="cpu", dtype=torch.int32))
+        res_mps = torch.remainder(
+            torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="mps"), torch.tensor(2, device="mps", dtype=torch.int32))
         self.assertEqual(res_cpu, res_mps)
 
-        res_cpu = torch.remainder(torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="cpu"), -1.5)
-        res_mps = torch.remainder(torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="mps"), -1.5)
+        res_cpu = torch.remainder(
+            torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="cpu"), -1.5)
+        res_mps = torch.remainder(
+            torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="mps"), -1.5)
         self.assertEqual(res_cpu, res_mps)
 
     def test_expand(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4282,6 +4282,15 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 6, 3, 5))
         helper((2, 8, 4, 5))
 
+    def test_remainder(self):
+        res_cpu = torch.remainder(torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="cpu"), torch.tensor(2, device="cpu", dtype=torch.int32))
+        res_mps = torch.remainder(torch.tensor([-3, -2, -1, 1, 2, 3], dtype=torch.int32, device="mps"), torch.tensor(2, device="mps", dtype=torch.int32))
+        self.assertEqual(res_cpu, res_mps)
+
+        res_cpu = torch.remainder(torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="cpu"), -1.5)
+        res_mps = torch.remainder(torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32, device="mps"), -1.5)
+        self.assertEqual(res_cpu, res_mps)
+
     def test_expand(self):
         def helper(n, c):
             values = [[1.0], [4.0], [7.0]]
@@ -10231,7 +10240,6 @@ class TestConsistency(TestCaseMPS):
         'polygammapolygamma_n_4': [torch.bool, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'qr': [torch.float32],
         'quantile': [torch.float32],
-        'remainder': [torch.bool, torch.int16, torch.int32, torch.int64, torch.uint8],
         'renorm': [torch.float16, torch.float32],
         'roll': [torch.bool, torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],
         'rsub': [torch.float16, torch.float32, torch.int16, torch.int32, torch.int64, torch.uint8],


### PR DESCRIPTION
Map remainder op to the same template as div