### PR TITLE
Update macOS 12 blocklist

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10463,6 +10463,7 @@ class TestConsistency(TestCaseMPS):
     }
 
     BLOCKLIST_MACOS_12 = {
+        # failures because of accumulate error exceeds atol/rtol
         '__rdiv__': [torch.float16],
 
         # expected failures

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10456,16 +10456,14 @@ class TestConsistency(TestCaseMPS):
         'addr',
 
         # for macOS 12
-        'masked.normalize', 'masked.sum',
+        'masked.normalize', 'masked.sum', 'masked.var',
         'outer',
-        'sum_to_size',
+        'sum_to_size', 'sum',
+        'mul',
     }
 
     BLOCKLIST_MACOS_12 = {
         '__rdiv__': [torch.float16],
-        'masked.var': [torch.float16],
-        'sum': [torch.float16],
-        'mul': [torch.float16],
 
         # expected failures
         'nn.functional.interpolatenearest': [torch.float32],


### PR DESCRIPTION
- move sum, masked.var, mul to low precision list
- unblock them from running