### PR TITLE
[CHERRY-PICK] Block uint8 data type for unary and binary ops on macOS 12. (#313)

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -26,6 +26,8 @@ typedef MPSGraphTensor* (^BinaryOpBlock)(BinaryOpCachedGraph*, MPSGraphTensor*, 
 void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha,
                     const Tensor& output_, std::string op_name, BinaryOpBlock binaryBlock)
 {
+  TORCH_CHECK(!(!is_macos_13_or_newer() && self.scalar_type() == ScalarType::Byte ),
+              "MPS support binary op with uint8 natively starting from macOS 13.0");
   TORCH_CHECK(!(op_name == "power" && !is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS) &&
               (self.scalar_type() == ScalarType::Long ||
               (other.scalar_type() == ScalarType::Long && (self.scalar_type() != ScalarType::Half && self.scalar_type() != ScalarType::Float)))),

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -16,6 +16,8 @@ bool is_empty_tensor(const Tensor& self) {
 
 void unary_op(const Tensor& self, const Tensor& output, std::string op_name, UnaryOpBlock unaryBlock, is_noop_p is_noop = is_empty_tensor)
 {
+  TORCH_CHECK(!(!is_macos_13_or_newer() && self.scalar_type() == ScalarType::Byte ),
+              "MPS support unary op with uint8 natively starting from macOS 13.0");
   if (!output.is_same_size(self)) {
     output.resize_(self.sizes());
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10464,7 +10464,7 @@ class TestConsistency(TestCaseMPS):
     BLOCKLIST_MACOS_12 = {
         '__rdiv__': [torch.float16],
         'masked.var': [torch.float16],
-        'sum': [torch.float16],
+        'neg': [torch.uint8],
         'mul': [torch.float16],
 
         # expected failures

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10464,7 +10464,7 @@ class TestConsistency(TestCaseMPS):
     BLOCKLIST_MACOS_12 = {
         '__rdiv__': [torch.float16],
         'masked.var': [torch.float16],
-        'neg': [torch.uint8],
+        'sum': [torch.float16],
         'mul': [torch.float16],
 
         # expected failures


### PR DESCRIPTION
@Ronian526 