### PR TITLE
Fix the uint8 type issue with View ops kernels

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -696,7 +696,7 @@ const std::string& getGatherScatterScalarType(const Tensor& t) {
     {c10::ScalarType::Int,   "int"},
     {c10::ScalarType::Short, "short"},
     {c10::ScalarType::Char,  "char"},
-    {c10::ScalarType::Byte,  "char"},
+    {c10::ScalarType::Byte,  "uchar"},
     {c10::ScalarType::Bool,  "bool"},
   };
 


### PR DESCRIPTION
This should fix the problem in Resnet model with image artifacts due to saturation on int8 type and also the incorrect class recognition reported in #86954.
