### PR TITLE
Fix view op slicing for 2nd dim in case of 0 offset

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -547,9 +547,10 @@ MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mp
   // There are cases where both dimensions of a view can shrink
   // E.g: x = torch.randn((3,6))[1, 1:3]
   int64_t nextSliceOffset = src.storage_offset() % view_numel;
-
   [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), static_cast<NSUInteger>(src.sizes()[firstDimToSlice])}];
-  if (nextSliceOffset) {
+  if ((firstDimToSlice < (src_base_shape.size() - 1)) &&
+      (src_view_shape[firstDimToSlice + 1] != src_base_shape[firstDimToSlice + 1])) {
+
     [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 2 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(nextSliceOffset), static_cast<NSUInteger>(src.sizes()[firstDimToSlice+1])}];
   }
 

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -485,7 +485,7 @@ bool canSliceViewTensor(const Tensor& src, MPSShape *mpsShape) {
   size_t src_ndim_view = getViewShape(src, mpsShape, false).size();
   size_t src_squeezed_ndim_view = src_view_squeezed_shape.size();
 
-  if (src_squeezed_ndim_base != src_squeezed_ndim_view && src_ndim_base != src_ndim_view) {
+  if (src_ndim_base != src_ndim_view) {
     return false;
   }
 
@@ -546,14 +546,19 @@ MPSGraphTensorData* getMPSGraphTensorDataForView(const Tensor& src, MPSShape *mp
   int64_t sliceOffset = src.storage_offset() / view_numel;
   // There are cases where both dimensions of a view can shrink
   // E.g: x = torch.randn((3,6))[1, 1:3]
-  int64_t nextSliceOffset = src.storage_offset() % view_numel;
-  [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), static_cast<NSUInteger>(src.sizes()[firstDimToSlice])}];
-  if ((firstDimToSlice < (src_base_shape.size() - 1)) &&
-      (src_view_shape[firstDimToSlice + 1] != src_base_shape[firstDimToSlice + 1])) {
+  int64_t nextSliceOffset = 0;
+  bool sliceNextDim = (firstDimToSlice < (src_base_shape.size() - 1)) &&
+                      (src_view_shape[firstDimToSlice + 1] != src_base_shape[firstDimToSlice + 1]);
 
+  [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 1 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(sliceOffset), static_cast<NSUInteger>(src.sizes()[firstDimToSlice])}];
+  if (sliceNextDim) {
+    if (firstDimToSlice + 1 == src_base_shape.size() - 1) {
+      nextSliceOffset = src.storage_offset() % src_base_shape[src_base_shape.size() - 1];
+    } else {
+      nextSliceOffset = (src.storage_offset() % view_numel) / (view_numel / src_base_shape[firstDimToSlice + 1]);
+    }
     [srcTensorNDArrayDesc sliceDimension:src_ndim_base - 2 - firstDimToSlice withSubrange:{static_cast<NSUInteger>(nextSliceOffset), static_cast<NSUInteger>(src.sizes()[firstDimToSlice+1])}];
   }
-
   srcTensorNDArrayView = [srcTensorNDArray arrayViewWithCommandBuffer:commandBuffer
                                                            descriptor:srcTensorNDArrayDesc
                                                              aliasing:MPSAliasingStrategyShallAlias];

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -622,7 +622,11 @@ class TestModule(TestCase):
     @modules(module_db)
     @skipIfTorchInductor("to be fixed")
     def test_memory_format(self, device, dtype, module_info, training):
-        msg = _get_mps_error_msg(device, dtype, module_info, [])
+        MPS_BLOCKLIST = [
+            "nn.BatchNorm3d",  # failed assert
+        ]
+
+        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
         if msg is not None:
             self.skipTest(msg)
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -56,11 +56,7 @@ class TestModule(TestCase):
 
     @modules(module_db)
     def test_forward(self, device, dtype, module_info, training):
-        MPS_BLOCKLIST = [
-            "nn.LSTM"  # segfault
-        ]
-
-        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
+        msg = _get_mps_error_msg(device, dtype, module_info, [])
         if msg is not None:
             self.skipTest(msg)
 
@@ -243,11 +239,7 @@ class TestModule(TestCase):
     def test_pickle(self, device, dtype, module_info, training):
         # Test that module can be pickled and unpickled.
 
-        MPS_BLOCKLIST = [
-            "nn.LSTM"  # hard crash
-        ]
-
-        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
+        msg = _get_mps_error_msg(device, dtype, module_info, [])
         if msg is not None:
             self.skipTest(msg)
 
@@ -287,11 +279,7 @@ class TestModule(TestCase):
         # Check if the inplace variant of the module gives the same result as the out of place
         # variant.
 
-        MPS_BLOCKLIST = [
-            "nn.ELU"  # hard crash
-        ]
-
-        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
+        msg = _get_mps_error_msg(device, dtype, module_info, [])
         if msg is not None:
             self.skipTest(msg)
 
@@ -376,14 +364,7 @@ class TestModule(TestCase):
     @skipIfTorchInductor("to be fixed")
     def test_non_contiguous_tensors(self, device, dtype, module_info, training):
         # Check modules work with non-contiguous tensors
-        MPS_BLOCKLIST = [
-            # hard crashes
-            "nn.GRU",
-            "nn.LSTM",
-            "nn.RNN"
-        ]
-
-        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
+        msg = _get_mps_error_msg(device, dtype, module_info, [])
         if msg is not None:
             self.skipTest(msg)
 
@@ -641,12 +622,7 @@ class TestModule(TestCase):
     @modules(module_db)
     @skipIfTorchInductor("to be fixed")
     def test_memory_format(self, device, dtype, module_info, training):
-        MPS_BLOCKLIST = [
-            "nn.BatchNorm3d",  # failed assert
-            "nn.LSTM",  # segfault
-        ]
-
-        msg = _get_mps_error_msg(device, dtype, module_info, MPS_BLOCKLIST)
+        msg = _get_mps_error_msg(device, dtype, module_info, [])
         if msg is not None:
             self.skipTest(msg)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1840,6 +1840,17 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(r_mps, r_cpu)
 
+    def test_contiguous_slice(self):
+        t_mps = torch.randn([3, 4], device="mps")
+        t_cpu = t_mps.detach().clone().cpu()
+
+        y_mps = t_mps[2:, :2]
+        y_cpu = t_cpu[2:, :2]
+
+        x_mps = y_mps + 1
+        x_cpu = y_cpu + 1
+        self.assertEqual(x_mps, x_cpu)
+
     def test_view_slice(self):
         # https://github.com/pytorch/pytorch/issues/83995
         NUM_SAMPLES = 60

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1840,16 +1840,62 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(r_mps, r_cpu)
 
-    def test_contiguous_slice(self):
-        t_mps = torch.randn([3, 4], device="mps")
-        t_cpu = t_mps.detach().clone().cpu()
+    def test_contiguous_slice_2d(self):
+        def helper(shape):
+            for i in range(0, shape[0]):
+                for j in range(0, shape[1]):
+                    t_mps = torch.randn(shape, device="mps")
+                    t_cpu = t_mps.detach().clone().cpu()
 
-        y_mps = t_mps[2:, :2]
-        y_cpu = t_cpu[2:, :2]
+                    y_mps = t_mps[i:, :j]
+                    y_cpu = t_cpu[i:, :j]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
 
-        x_mps = y_mps + 1
-        x_cpu = y_cpu + 1
-        self.assertEqual(x_mps, x_cpu)
+                    y_mps = t_mps[i:, j]
+                    y_cpu = t_cpu[i:, j]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
+
+                    y_mps = t_mps[i, :j]
+                    y_cpu = t_cpu[i, :j]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
+
+                    y_mps = t_mps[:i, :j]
+                    y_cpu = t_cpu[:i, :j]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
+
+                    y_mps = t_mps[:i, j]
+                    y_cpu = t_cpu[:i, j]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
+
+                    y_mps = t_mps[:i, j:]
+                    y_cpu = t_cpu[:i, j:]
+                    self.assertEqual(y_mps + 1, y_cpu + 1)
+
+        l = []
+        for N in range(1, 3):
+            l.append(N)
+            for C in range(1, 3):
+                l.append(C)
+                helper(l)
+                for D in range(1, 3):
+                    l.append(D)
+                    helper(l)
+                    for H in range(1, 3):
+                        l.append(H)
+                        helper(l)
+                        for W in range(1, 3):
+                            l.append(W)
+                            helper(l)
+                            l.pop()
+                        l.pop()
+                    l.pop()
+                l.pop()
+            l.pop()
+
+        helper([9, 15, 4])
+        helper([9, 3, 2])
+        helper([3, 4, 18, 22])
+        helper([3, 4, 18, 22, 150])
 
     def test_view_slice(self):
         # https://github.com/pytorch/pytorch/issues/83995


### PR DESCRIPTION
Fixes slicing of view ops when both dimensions need to be sliced and the 2nd dimension to be sliced has an offset of 0.
e.g in case of base shape `[3, 4]` and view shape `[1, 2] storrage_offset=8`, both dimensions of the base shape would need to be sliced. The offset for the first element in the 2nd dimension is 0, which was causing the previous check ` if (nextSliceOffset)` to fail. This change fixes the condition so an offset of 0 won't be ignored. 

 