### PR TITLE
Add warning to int upcast which causes precision errors for atanh and…

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -97,6 +97,8 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
           ScalarType common_dtype = c10::promoteTypes(inputDataType, otherDataType);
           if (isIntegralType(common_dtype, true)) {
             // integer inputs must be cast to float, if output is float
+            TORCH_WARN_ONCE("Integer intput is being casted to float for binary op.\n",
+                            "This may result in minor precision issues.\n");
             if (isFloatingType(outputDataType)) {
               common_dtype = outputDataType;
             // in boolean comparison ops with signed vs. unsigned integers, we always cast to the unsigned type


### PR DESCRIPTION
… other binary ops


Casting args from int to float can cause precision issues in some cases. Adding a warning may be preferable to disabling the op, since the failures are relatively small and don't occur in all cases