### PR TITLE
Add truncateWithTensor to VenturaOps (supported only from 13.0 and above)

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphVenturaOps.h
@@ -61,6 +61,9 @@ typedef NS_ENUM(NSUInteger, MPSGraphResizeNearestRoundingMode)
 - (MPSGraphTensor * _Nonnull)inverseOfTensor:(MPSGraphTensor * _Nonnull) inputTensor
                                         name:(NSString * _Nullable)name;
 
+- (MPSGraphTensor * _Nonnull) truncateWithTensor:(MPSGraphTensor * _Nonnull) tensor
+                                            name:(NSString * _Nullable) name;
+
 - (MPSGraphTensor * _Nonnull) resizeNearestWithTensor:(MPSGraphTensor * _Nonnull) imagesTensor
                                            sizeTensor:(MPSGraphTensor * _Nonnull) size
                                   nearestRoundingMode:(MPSGraphResizeNearestRoundingMode) nearestRoundingMode


### PR DESCRIPTION
`truncateWithTensor` started being supported only from 13.0 and above. Previous to that the selector was inexistent. 