### PR TITLE
Reduce numbers of graph compilations for unary/binary/reduction ops

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -71,7 +71,7 @@ public:
                      size_t length, size_t srcOffset, size_t dstOffset, bool non_blocking);
   void flush();
   void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
-  void executeMPSGraph(NSObject* theExecutable, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
+  void executeMPSGraph(MPSGraphExecutable* executable, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
 
   void addCompletedHandler(MTLCommandBufferHandler block);
 

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -71,6 +71,8 @@ public:
                      size_t length, size_t srcOffset, size_t dstOffset, bool non_blocking);
   void flush();
   void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
+  void executeMPSGraph(NSObject* theExecutable, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
+
   void addCompletedHandler(MTLCommandBufferHandler block);
 
   /// Get the MPS device index that this stream is associated with.

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -156,8 +156,7 @@ void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer, 
 }
 
 void
-MPSStream::executeMPSGraph(NSObject* theExecutable, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
-  MPSGraphExecutable *executable = (MPSGraphExecutable *)theExecutable;
+MPSStream::executeMPSGraph(MPSGraphExecutable* executable, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
     @autoreleasepool {
       NSMutableArray *inputs = [NSMutableArray arrayWithCapacity:[[executable feedTensors] count]];

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -155,6 +155,49 @@ void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer, 
        !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT);
 }
 
+void
+MPSStream::executeMPSGraph(NSObject* theExecutable, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
+  MPSGraphExecutable *executable = (MPSGraphExecutable *)theExecutable;
+  dispatch_sync(_serialQueue, ^() {
+    @autoreleasepool {
+      NSMutableArray *inputs = [NSMutableArray arrayWithCapacity:[[executable feedTensors] count]];
+      NSUInteger inputIndex = 0;
+
+      for (MPSGraphTensor *tensor in [executable feedTensors]) {
+        inputs[inputIndex++] = feeds[tensor];
+      }
+
+      NSMutableArray *outputs = [NSMutableArray arrayWithCapacity:[[executable targetTensors] count]];
+      NSUInteger ouputIndex = 0;
+
+      for (MPSGraphTensor *tensor in [executable targetTensors]) {
+        outputs[ouputIndex++] = results[tensor];
+      }
+
+      MPSGraphExecutableExecutionDescriptor *executionDescriptor =
+                        [[MPSGraphExecutableExecutionDescriptor new] autorelease];
+
+      executionDescriptor.completionHandler = ^(NSArray<MPSGraphTensorData *> * _Nonnull,
+                                                NSError * _Nullable) {
+
+      };
+#if USE_COMMIT_AND_CONTINUE
+      [executable encodeToCommandBuffer:commandBuffer()
+                            inputsArray:inputs
+                           resultsArray:outputs
+                    executionDescriptor:executionDescriptor];
+      synchronize(syncType);
+#else
+      commit(true);
+      [executable runAsyncWithMTLCommandQueue:_commandQueue
+                                  inputsArray:inputs
+                                  resultsArray:outputs
+                          executionDescriptor:executionDescriptor];
+#endif // !USE_MPSCOMMANDBUFFER
+    }
+  });
+}
+
 void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
 #if USE_COMMIT_AND_CONTINUE

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -42,10 +42,13 @@ void runMPSGraph(
     NSDictionary* results);
 
 void runMPSGraphExecutable(
-  MPSStream *metalStream,
-  NSObject* theExecutable,
+  MPSStream *mpsStream,
+  MPSGraph* mpsGraph,
+  MPSGraphTensor* outputTensor,
   NSDictionary *feeds,
+  NSDictionary *shapes,
   NSDictionary *results);
+
 
 MPSDataType getMPSDataType(ScalarType scalar_type);
 MPSDataType getMPSScalarType(ScalarType scalar_type);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -53,7 +53,7 @@ MPSScalar   getMPSScalar(const Scalar& scalar, ScalarType type);
 std::string getMPSTypeString(ScalarType scalar_type, bool short_name = false);
 std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t);
-NSArray<NSNumber*>* getTensorAxes(const Tensor& t, at::OptionalIntArrayRef dim);
+NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);
 std::string getMPSShapeString(MPSShape* shape);
 std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = false, bool disable_type_inference = false);
 std::string getArrayRefString(const IntArrayRef s);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -55,7 +55,7 @@ std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t, at::OptionalIntArrayRef dim);
 std::string getMPSShapeString(MPSShape* shape);
-std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = false);
+std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = false, bool disable_type_inference = false);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -41,6 +41,12 @@ void runMPSGraph(
     NSDictionary* feeds,
     NSDictionary* results);
 
+void runMPSGraphExecutable(
+  MPSStream *metalStream,
+  NSObject* theExecutable,
+  NSDictionary *feeds,
+  NSDictionary *results);
+
 MPSDataType getMPSDataType(ScalarType scalar_type);
 MPSDataType getMPSScalarType(ScalarType scalar_type);
 MPSScalar   getMPSScalar(const Scalar& scalar, ScalarType type);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -9,8 +9,19 @@ void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds, 
   mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE);
 }
 
-void runMPSGraphExecutable(MPSStream *mpsStream, NSObject* theExecutable, NSDictionary *feeds, NSDictionary *results) {
-  mpsStream->executeMPSGraph(theExecutable, feeds, results, SyncType::COMMIT_ADAPTIVE);
+void runMPSGraphExecutable(MPSStream *mpsStream, MPSGraph* mpsGraph, MPSGraphTensor* outputTensor, NSDictionary *feeds, NSDictionary *shapes, NSDictionary *results) {
+  @autoreleasepool {
+    MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
+    [compilationDescriptor disableTypeInference];
+
+    MPSGraphExecutable* executable = [[mpsGraph compileWithDevice:nil
+                                                            feeds:shapes
+                                                    targetTensors:@[outputTensor]
+                                                 targetOperations:nil
+                                              compilationDescriptor:compilationDescriptor] retain];
+
+    mpsStream->executeMPSGraph(executable, feeds, results, SyncType::COMMIT_ADAPTIVE);
+  }
 }
 
 MPSDataType getMPSDataType(ScalarType scalar_type) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -149,8 +149,7 @@ std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type) {
   }
 }
 
-NSArray<NSNumber*>* getTensorAxes(const Tensor& t) {
-  int64_t ndim = t.dim();
+NSArray<NSNumber*>* getTensorAxes(int64_t ndim) {
   auto axes = [NSMutableArray<NSNumber*> arrayWithCapacity:ndim];
   for (const auto i: c10::irange(ndim)) {
     axes[i] = [NSNumber numberWithInteger:i];
@@ -158,7 +157,15 @@ NSArray<NSNumber*>* getTensorAxes(const Tensor& t) {
   return axes;
 }
 
-NSArray<NSNumber*>* getTensorAxes(const Tensor& t, at::OptionalIntArrayRef dim) {
+NSArray<NSNumber*>* getTensorAxes(const Tensor& t) {
+  return getTensorAxes(t.dim());
+}
+
+NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes) {
+  return getTensorAxes(sizes.size());
+}
+
+NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim) {
   if (dim.has_value() && dim.value().size() != 0) {
     IntArrayRef dimValues = dim.value();
     int ndim = dimValues.size();
@@ -170,7 +177,7 @@ NSArray<NSNumber*>* getTensorAxes(const Tensor& t, at::OptionalIntArrayRef dim) 
     return axes;
   }
 
-  return getTensorAxes(t);
+  return getTensorAxes(sizes);
 }
 
 std::string getMPSShapeString(MPSShape* shape) {

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -78,7 +78,9 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
-    string key = op_name + getTensorsStringKey({self, other, output_});
+    string key = op_name + std::to_string(self.dim())    + ":"  + getMPSTypeString(self.scalar_type())
+                         + std::to_string(other.dim())   + ":" + getMPSTypeString(other.scalar_type())
+                         + std::to_string(output_.dim()) + getMPSTypeString(output_.scalar_type());
     BinaryOpCachedGraph* cachedGraph = static_cast<BinaryOpCachedGraph *>(cache_->LookUp(key));
 
     if(!cachedGraph) {
@@ -87,8 +89,8 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
         @autoreleasepool {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new BinaryOpCachedGraph(mpsGraph);
-          newCachedGraph->primaryTensor   = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType), getMPSShape(self));
-          newCachedGraph->secondaryTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType), getMPSShape(other));
+          newCachedGraph->primaryTensor   = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType));
+          newCachedGraph->secondaryTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType));
 
           MPSGraphTensor* primaryCastTensor   = newCachedGraph->primaryTensor;
           MPSGraphTensor* secondaryCastTensor = newCachedGraph->secondaryTensor;

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -178,18 +178,9 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
       shapes[cachedGraph->secondaryTensor] = [[[MPSGraphShapedType alloc] initWithShape:nil dataType:getMPSScalarType(otherDataType)] autorelease];
       if (cachedGraph->alphaTensor) {
         shapes[cachedGraph->alphaTensor] = [[[MPSGraphShapedType alloc] initWithShape:@[@1] dataType:getMPSScalarType(otherDataType)] autorelease];
-
       }
 
-      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
-      [compilationDescriptor disableTypeInference];
-
-      MPSGraphExecutable* executable = [[cachedGraph->graph() compileWithDevice:nil
-                                                                          feeds:shapes
-                                                                  targetTensors:@[cachedGraph->outputTensor]
-                                                               targetOperations:nil
-                                                           compilationDescriptor:compilationDescriptor] retain];
-      runMPSGraphExecutable(mpsStream, executable, feeds, results);
+      runMPSGraphExecutable(mpsStream, cachedGraph->graph(), cachedGraph->outputTensor, feeds, shapes, results);
     } else {
       runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
     }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1,4 +1,4 @@
-//  Copyright © 2022 Apple Inc.
+git//  Copyright © 2022 Apple Inc.
 
 #include <ATen/ATen.h>
 #include <ATen/Tensor.h>
@@ -175,10 +175,10 @@ void reduction_out_mps(
     NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];
     string key = func_name                                 + ":" +
                  string([ns_key UTF8String])               + ":" +
-                 getTensorsStringKey(input_t)              + ":" +
+                 std::to_string(input_t.dim()) + ":" + getMPSTypeString(input_t.scalar_type()) + ":" +
                  std::to_string(keepdim)                   + ":" +
                  std::to_string(reduction_type)            + ":" +
-                 getTensorsStringKey(output_t)             + ":" +
+                 std::to_string(output_t.dim()) + ":" + getMPSTypeString(output_t.scalar_type()) + ":" +
                  dtype_str;
     using CachedGraph = MPSUnaryCachedGraph;
     auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
@@ -193,7 +193,7 @@ void reduction_out_mps(
           newCachedGraph = new CachedGraph(mpsGraph);
           auto inputScalarType = input_t.scalar_type();
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
           MPSGraphTensor* castInputTensor = inputTensor;
           MPSDataType inputCastType = MPSDataTypeInvalid;
           if (dtype.has_value() &&

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -300,15 +300,7 @@ void reduction_out_mps(
       NSDictionary<MPSGraphTensor*, MPSGraphShapedType *>* shapes = @{
         cachedGraph->inputTensor_ : [[[MPSGraphShapedType alloc] initWithShape:nil dataType:getMPSScalarType(input_t.scalar_type())] autorelease]
       };
-      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
-      [compilationDescriptor disableTypeInference];
-
-      MPSGraphExecutable* executable = [[cachedGraph->graph() compileWithDevice:nil
-                                                              feeds:shapes
-                                                      targetTensors:@[cachedGraph->outputTensor_]
-                                                    targetOperations:nil
-                                              compilationDescriptor:compilationDescriptor] retain];
-      runMPSGraphExecutable(stream, executable, feeds, results);
+      runMPSGraphExecutable(stream, cachedGraph->graph(), cachedGraph->outputTensor_, feeds, shapes, results);
     } else {
       runMPSGraph(stream, cachedGraph->graph(), feeds, results);
     }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1,4 +1,4 @@
-git//  Copyright © 2022 Apple Inc.
+//  Copyright © 2022 Apple Inc.
 
 #include <ATen/ATen.h>
 #include <ATen/Tensor.h>

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -25,10 +25,10 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
     output.copy_(self);
     return;
   }
+  bool disableTypeInference = true;
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
-    string key = op_name + std::to_string(self.dim())    + ":"  + getMPSTypeString(self.scalar_type()) +
-                            std::to_string(output.dim())    + ":"  + getMPSTypeString(output.scalar_type());
+    string key = op_name + getTensorsStringKey({self, output}, false, disableTypeInference);
     auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
 
     if(!cachedGraph) {
@@ -37,7 +37,9 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
         @autoreleasepool {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
-          newCachedGraph->inputTensor_ = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
+          newCachedGraph->inputTensor_ = disableTypeInference ?
+                mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type())) :
+                mpsGraphRankedPlaceHolder(mpsGraph, self);
           MPSGraphTensor* castTensor = newCachedGraph->inputTensor_;
           // Integer input must be cast to float if output is float
           if (isIntegralType(self.scalar_type(), true) && isFloatingType(output.scalar_type())) {
@@ -62,7 +64,22 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    if (disableTypeInference) {
+      NSDictionary<MPSGraphTensor*, MPSGraphShapedType *>* shapes = @{
+        cachedGraph->inputTensor_ : [[[MPSGraphShapedType alloc] initWithShape:nil dataType:getMPSScalarType(self.scalar_type())] autorelease]
+      };
+      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
+      [compilationDescriptor disableTypeInference];
+
+      MPSGraphExecutable* executable = [[cachedGraph->graph() compileWithDevice:nil
+                                                              feeds:shapes
+                                                      targetTensors:@[cachedGraph->outputTensor_]
+                                                    targetOperations:nil
+                                              compilationDescriptor:compilationDescriptor] retain];
+      runMPSGraphExecutable(getCurrentMPSStream(), executable, feeds, results);
+    } else {
+      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    }
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -68,15 +68,7 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
       NSDictionary<MPSGraphTensor*, MPSGraphShapedType *>* shapes = @{
         cachedGraph->inputTensor_ : [[[MPSGraphShapedType alloc] initWithShape:nil dataType:getMPSScalarType(self.scalar_type())] autorelease]
       };
-      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
-      [compilationDescriptor disableTypeInference];
-
-      MPSGraphExecutable* executable = [[cachedGraph->graph() compileWithDevice:nil
-                                                              feeds:shapes
-                                                      targetTensors:@[cachedGraph->outputTensor_]
-                                                    targetOperations:nil
-                                              compilationDescriptor:compilationDescriptor] retain];
-      runMPSGraphExecutable(getCurrentMPSStream(), executable, feeds, results);
+      runMPSGraphExecutable(getCurrentMPSStream(), cachedGraph->graph(), cachedGraph->outputTensor_, feeds, shapes, results);
     } else {
       runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
     }

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -27,7 +27,8 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
   }
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
-    string key = op_name + getTensorsStringKey({self, output});
+    string key = op_name + std::to_string(self.dim())    + ":"  + getMPSTypeString(self.scalar_type()) +
+                            std::to_string(output.dim())    + ":"  + getMPSTypeString(output.scalar_type());
     auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
 
     if(!cachedGraph) {
@@ -36,7 +37,7 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
         @autoreleasepool {
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
-          newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, self);
+          newCachedGraph->inputTensor_ = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
           MPSGraphTensor* castTensor = newCachedGraph->inputTensor_;
           // Integer input must be cast to float if output is float
           if (isIntegralType(self.scalar_type(), true) && isFloatingType(output.scalar_type())) {


### PR DESCRIPTION
Reduce the number of graph compilations for binary/unary/ops (helps with the cases when the shapes of the tensors keep changing very frequently)