### PR TITLE
Calculate nonzero count first before running nonzero op

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -157,15 +157,13 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
       }
     }
 
-    size_t size_to_copy = src.nbytes();
+    size_t size_to_copy = dst.nbytes();
     // In case of dtype change, first convert src inplace
     if (src_.dtype() != dst.dtype()) {
       copy_cast_mps(dst, src, tmpBuffer, sourceBuffer, non_blocking);
     }
 
     if (needsBlit) {
-      size_to_copy = (size_to_copy / src.element_size()) * dst.element_size();
-
       // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.
       TORCH_INTERNAL_ASSERT(sourceBuffer && dst_tensor_nbytes > 0);
 

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -157,13 +157,15 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
       }
     }
 
-    size_t size_to_copy = dst.nbytes();
+    size_t size_to_copy = src.nbytes();
     // In case of dtype change, first convert src inplace
     if (src_.dtype() != dst.dtype()) {
       copy_cast_mps(dst, src, tmpBuffer, sourceBuffer, non_blocking);
     }
 
     if (needsBlit) {
+      size_to_copy = (size_to_copy / src.element_size()) * dst.element_size();
+
       // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.
       TORCH_INTERNAL_ASSERT(sourceBuffer && dst_tensor_nbytes > 0);
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -270,7 +270,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
     return out_;
   }
 
-  bool contiguous_output = (out_.is_contiguous() && !out_.is_view());
+  bool contiguous_output = out_.is_contiguous();
   Tensor out = out_;
   if (!contiguous_output) {
     out = at::native::empty_mps(

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -394,7 +394,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
   if (!contiguous_output) {
     out_.copy_(out);
   }
- 
+
   return out_;
 }
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -312,7 +312,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
+          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
           MPSGraphTensor *scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
           MPSGraphTensor *oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -300,7 +300,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
-    string key = "nonzero_out_mps" + getTensorsStringKey(self, false, true);
+    string key = "nonzero_out_mps" + getTensorsStringKey(self);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
     if(!cachedGraph) {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -261,24 +261,32 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
     MPSGraphTensor* inputTensor_ = nil;
     MPSGraphTensor* outputTensor_ = nil;
     MPSGraphTensor* scatterDataTensor_ = nil;
-    MPSGraphTensor* countNonzeroTensor_ = nil;
   };
 
   stream->synchronize(SyncType::COMMIT_AND_WAIT);
-  Tensor count_nonzero = at::empty({1}, self.options().dtype(kInt));
-  Tensor out =  at::native::empty_mps(
-           {self.numel(), nDim == 0 ? 1 : nDim},
+  int64_t total_nonzero = at::count_nonzero(self).item<int64_t>();
+  at::native::resize_output(out_, {total_nonzero, nDim});
+  if (out_.numel() ==  0) {
+    return out_;
+  }
+
+  bool contiguous_output = (out_.is_contiguous() && !out_.is_view());
+  Tensor out = out_;
+  if (!contiguous_output) {
+    out = at::native::empty_mps(
+           out_.sizes(),
            out_.scalar_type(),
            c10::nullopt,
            kMPS,
            c10::nullopt,
            c10::nullopt);
+  }
 
   int64_t _apparentInputShape = 1;
   for (auto dim : self.sizes()) {
     _apparentInputShape *= dim;
   }
-  MPSShape *apparentOutputShape = @[@(self.numel() * nDim)];
+  MPSShape *apparentOutputShape = @[@(total_nonzero * nDim)];
   MPSShape *apparentInputShape = @[@(_apparentInputShape)];
 
   // Pseudocode:
@@ -292,7 +300,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
 
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
-    string key = "nonzero_out_mps" + getTensorsStringKey(self);
+    string key = "nonzero_out_mps" + getTensorsStringKey(self, false, true);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
     if(!cachedGraph) {
@@ -304,7 +312,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
+          MPSGraphTensor *inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
           MPSGraphTensor *scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
           MPSGraphTensor *oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];
@@ -312,9 +320,6 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraphTensor *inputNotEqualToZeroTensor = [mpsGraph notEqualWithPrimaryTensor:inputTensor
                                                                           secondaryTensor:zeroTensor
                                                                                      name:nil];
-          MPSGraphTensor *countNonzero = [mpsGraph reductionSumWithTensor:inputNotEqualToZeroTensor
-                                                         axis:0
-                                                         name:nil];
           MPSGraphTensor *maskTensor = [mpsGraph castTensor:inputNotEqualToZeroTensor
                                                      toType:MPSDataTypeInt32
                                                        name:@"castToInt32"];
@@ -363,7 +368,6 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           newCachedGraph->inputTensor_ = inputTensor;
           newCachedGraph->scatterDataTensor_ = scatterDataTensor;
           newCachedGraph->outputTensor_ = outputTensor;
-          newCachedGraph->countNonzeroTensor_ = countNonzero;
         }
         return newCachedGraph;
       });
@@ -371,7 +375,6 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
     }
 
     Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, apparentInputShape);
-    Placeholder countNonzeroPlaceholder = Placeholder(cachedGraph->countNonzeroTensor_, count_nonzero);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out, apparentOutputShape);
     Placeholder scatterPlaceholder = Placeholder(cachedGraph->scatterDataTensor_, out, apparentOutputShape);
 
@@ -383,15 +386,15 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
 
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-      countNonzeroPlaceholder.getMPSGraphTensor() : countNonzeroPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraphExecutable(stream, cachedGraph, feeds, results);
   }
 
-  int32_t total_nonzero = count_nonzero.item<int32_t>();
-  at::native::resize_output(out_, {total_nonzero, nDim});
-  out_.copy_(out.resize_({total_nonzero, nDim}));
+  if (!contiguous_output) {
+    out_.copy_(out);
+  }
+ 
   return out_;
 }
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -312,7 +312,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparent_input_shape);
+          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
           MPSGraphTensor *scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
           MPSGraphTensor *oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -312,7 +312,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparentInputShape);
+          MPSGraphTensor *inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
           MPSGraphTensor *scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
           MPSGraphTensor *oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -312,7 +312,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()));
+          MPSGraphTensor *inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), apparent_input_shape);
           MPSGraphTensor *scatterDataTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSScalarType(out.scalar_type()));
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputDataType];
           MPSGraphTensor *oneTensor = [mpsGraph constantWithScalar:1.0 dataType:MPSDataTypeInt32];
@@ -388,7 +388,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_){
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
     };
 
-    runMPSGraphExecutable(stream, cachedGraph, feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   if (!contiguous_output) {

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -23,9 +23,9 @@ Scalar _local_scalar_dense_mps(const Tensor& self) {
 
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_mps", [&] {
-        Tensor output = at::empty_like(self, kCPU);
+        Tensor output = at::empty({1}, TensorOptions(at::CPU(self.scalar_type())));
 
-        Tensor cpu_output = mps::mps_copy_(output, self, false);
+        mps::mps_copy_(output, self, false);
         scalar_t value = *cpu_output.data_ptr<scalar_t>();
         r = Scalar(value);
    });

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -26,7 +26,7 @@ Scalar _local_scalar_dense_mps(const Tensor& self) {
         Tensor output = at::empty({1}, TensorOptions(at::CPU(self.scalar_type())));
 
         mps::mps_copy_(output, self, false);
-        scalar_t value = *cpu_output.data_ptr<scalar_t>();
+        scalar_t value = *output.data_ptr<scalar_t>();
         r = Scalar(value);
    });
 


### PR DESCRIPTION
Summary of changes:
- Calculate nonzero count first before running nonzero op
- allocate only 1 element when calling .item(), and blit only the size of destination
- Disable type inference for nonzero (output shape changes very frequently)