### PR TITLE
Add CPU Fallback profiling, and capture SIGINT

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -445,7 +445,7 @@ string get_mem_format_string(c10::MemoryFormat memory_format) {
 MPSGraphCache* MPSGraphCache::_instance_cache = nullptr;
 
 void MPSGraphCache::profileCachedGraph(const CacheEntry& cacheEntry) const {
-  MPSProfiler& profiler = getMPSProfiler();
+  auto& profiler = getMPSProfiler();
   if (profiler.isGraphProfilingEnabled()) {
     std::string graphKey = cacheEntry.key_;
     // for interval-based signpost tracing, we begin the interval here to be able


### PR DESCRIPTION
- This patch adds support for dumping info of the ops that fallback on CPU including CPU times and Copy Overhead (for copying input tensors to CPU and result back to MPS).
- Added signpost tracing for CPU fallbacks.
- Enabled capturing SIGINT to display profiling stats when process is terminated with CTRL+C.

