### PR TITLE
Use memcpy() to copy scalar tensors on unified memory

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -27,6 +27,7 @@ static const size_t kSmallHeap     = MB(8);    // "small" allocations are packed
 static const size_t kLargeHeap     = MB(32);   // "large" allocations may be packed in 32 MiB heaps
 static const size_t kXLargeHeapD   = MB(128);  // "extra large" allocations on Discrete devices may be packed in 128 MiB heaps
 static const size_t kXLargeHeapU   = MB(1024); // "extra large" allocations on Unified devices may be packed in 1 GiB heaps
+static const size_t kMaxScalarAlloc= (sizeof(int64_t)); // largest "scalar" allocation
 
 // buffer pools could be customized with a combination of usage flags
 enum UsageFlags : uint32_t {
@@ -52,6 +53,7 @@ struct HeapBlock;
 struct BufferBlock
 {
   id<MTLBuffer> buffer;
+  void* cpu_ptr; // stores the pointer to CPU mapping of a Shared MTLBuffer
   size_t size; // size after alignment
   size_t requested_size; // requested size (before alignment)
   // buffer shape is used for retrieving base of views in cached graphs
@@ -67,7 +69,7 @@ struct BufferBlock
 
   BufferBlock(size_t Size, size_t RequestedSize = 0, const id<MTLBuffer> Buffer = nullptr,
               HeapBlock* Heap = nullptr) :
-              buffer(Buffer), size(Size), requested_size(RequestedSize),
+              buffer(Buffer), cpu_ptr(nullptr), size(Size), requested_size(RequestedSize),
               in_use(false), heap(Heap), buf_id(++buffer_counter), gc_count(0), use_count(0) { }
 
   static bool Comparator(const BufferBlock* a, const BufferBlock* b) {
@@ -266,6 +268,9 @@ public:
   IntArrayRef getBufferShape(void* ptr);
   // allocate a buffer from a specialized pool to import CPU scalars into GPU
   id<MTLBuffer> allocScalarBufferWithValue(void* value, size_t size);
+  // returns a CPU-mapping of the input buffer and its retainCount,
+  // if only it has Shared storage-mode and allocated on MPSAllocator
+  std::pair<void*, uint32_t> getSharedBufferPtr(void* buffer);
   // this indicates how far (in Megabytes) the current total allocations are from the
   // low watermark limit which is used to detect if we're under memory pressure
   // This returns zero if we've reached the low watermark limit
@@ -357,8 +362,12 @@ private:
   void garbage_collect_cached_buffers(AllocParams& params);
 
   BufferPool& get_pool(size_t Size, uint32_t usage) {
-    if (usage & UsageFlags::SCALAR)
+    if (usage & UsageFlags::SCALAR) {
       return m_scalar_pool;
+    }
+    if (Size <= kMaxScalarAlloc && m_device.hasUnifiedMemory) {
+      return m_small_pool_shared;
+    }
     return Size <= kMaxSmallAlloc ? ((usage & UsageFlags::SHARED) ? m_small_pool_shared : m_small_pool_private) :
                                     ((usage & UsageFlags::SHARED) ? m_large_pool_shared : m_large_pool_private);
   }

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -29,6 +29,7 @@ public:
   virtual size_t getTotalAllocatedMemory() const = 0;
   virtual size_t getCurrentAllocatedMemory() const = 0;
   virtual size_t getDriverAllocatedMemory() const = 0;
+  virtual std::pair<void*, uint32_t> getSharedBufferPtr(void* buffer) const = 0;
 };
 
 class IMpsAllocatorCallback {

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -94,6 +94,7 @@ private:
   Stream _stream;
   MTLCommandQueue_t _commandQueue = nil;
   MPSCommandBuffer* _commandBuffer = nil;
+  MPSCommandBuffer* _prevCommandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
 

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -122,6 +122,7 @@ void MPSStream::flush() {
     // if commitAndContinue is disabled (e.g., for Profiler), we keep the command
     // buffer so we could wait on it later, if required.
     if (!_enableCommitAndContinue) {
+      TORCH_INTERNAL_ASSERT(getMPSProfiler().isSignpostTracingEnabled());
       _prevCommandBuffer = _commandBuffer;
     } else {
       [_commandBuffer release];

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -54,14 +54,12 @@ id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
 
 void MPSStream::synchronize(SyncType syncType) {
   endKernelCoalescing();
-  if (!_commandBuffer)
-    return;
   switch(syncType) {
     case SyncType::NONE:
       // typically in GPU to GPU copies we won't commit explicitly
       break;
     case SyncType::COMMIT:
-      flush();
+      commit();
       break;
     case SyncType::COMMIT_ADAPTIVE:
       // the adaptive commit only commits if we hit the low watermark memory threshold
@@ -89,11 +87,20 @@ void MPSStream::commit() {
 }
 
 void MPSStream::commitAndWait() {
-  assert(_commandBuffer);
-  [_commandBuffer commit];
-  [_commandBuffer waitUntilCompleted];
-  [_commandBuffer release];
-  _commandBuffer = nil;
+  if (_prevCommandBuffer) {
+    // the previous command buffer (if exists) has already been committed,
+    // so we just wait until it's completed and then dispose it.
+    [_prevCommandBuffer waitUntilCompleted];
+    [_prevCommandBuffer release];
+    _prevCommandBuffer = nil;
+  }
+
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    [_commandBuffer waitUntilCompleted];
+    [_commandBuffer release];
+    _commandBuffer = nil;
+  }
 }
 
 void MPSStream::commitAndContinue() {
@@ -112,7 +119,13 @@ void MPSStream::endKernelCoalescing() {
 void MPSStream::flush() {
   if (_commandBuffer) {
     [_commandBuffer commit];
-    [_commandBuffer release];
+    // if commitAndContinue is disabled (e.g., for Profiler), we keep the command
+    // buffer so we could wait on it later, if required.
+    if (!_enableCommitAndContinue) {
+      _prevCommandBuffer = _commandBuffer;
+    } else {
+      [_commandBuffer release];
+    }
     _commandBuffer = nil;
   }
 }

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -318,6 +318,41 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   return dst_;
 }
 
+// tries to copy scalar buffers if any of them are allocated on MPSAllocator
+// with Shared-storage mode on Unified devices (supports CPU <-> MPS copies only).
+static bool try_copy_scalars_mps(at::Tensor& dst, const at::Tensor& src, bool non_blocking)
+{
+  const auto& allocator = *getIMPSAllocator();
+  if (!allocator.isSharedStorageSupported()) {
+    return false;
+  }
+  void* src_ptr = src.storage().data();
+  void* dst_ptr = dst.storage().data();
+  uint32_t retainCount = 0;
+
+  if (src.device().type() == at::kMPS) {
+    std::tie(src_ptr, retainCount) = allocator.getSharedBufferPtr(src_ptr);
+  }
+  if (dst.device().type() == at::kMPS) {
+    std::tie(dst_ptr, retainCount) = allocator.getSharedBufferPtr(dst_ptr);
+  }
+  if (!src_ptr || !dst_ptr) {
+    return false;
+  }
+  size_t src_offset = src.storage_offset() * src.itemsize();
+  size_t dst_offset = dst.storage_offset() * dst.itemsize();
+  size_t length = std::min(src.nbytes(), dst.nbytes());
+  bool needsSync = !non_blocking && retainCount > 1;
+
+  if (needsSync) {
+    // wait for any possible GPU operations to finish before reading from source MPS buffers
+    getDefaultMPSStream()->synchronize(SyncType::COMMIT_AND_WAIT);
+  }
+  memcpy((char*) dst_ptr + dst_offset, (char*) src_ptr + src_offset, length);
+
+  return true;
+}
+
 at::Tensor& mps_copy_(at::Tensor& dst, const at::Tensor& src, bool non_blocking)
 {
   TORCH_CHECK(dst.defined(), "dst is undefined");
@@ -335,6 +370,17 @@ at::Tensor& mps_copy_(at::Tensor& dst, const at::Tensor& src, bool non_blocking)
     needs_broadcasting = true;
   }
 
+  // copying scalars from MPS to MPS is possible with try_copy_scalars_mps(), but it
+  // may require syncing with CPU. So it's better to use blit encoder without syncing.
+  if (src.device().type() == at::kMPS && dst.device().type() == at::kMPS) {
+    return copy_kernel_mps(dst, needs_broadcasting ? src.expand_as(dst) : src, non_blocking);
+  }
+  // for scalar tensors, try to copy with memcpy (if Unified memory)
+  if (src.dim() == 0 && src.dtype() == dst.dtype()) {
+    if (try_copy_scalars_mps(dst, src, non_blocking)) {
+      return dst;
+    }
+  }
   if (src.device().type() == at::kMPS && dst.device().type() == at::kCPU) {
     return copy_from_mps_(dst, needs_broadcasting ? src.expand_as(dst) : src, non_blocking);
   }
@@ -342,9 +388,6 @@ at::Tensor& mps_copy_(at::Tensor& dst, const at::Tensor& src, bool non_blocking)
     return copy_to_mps_(dst, needs_broadcasting ? src.expand_as(dst) : src, non_blocking);
   }
 
-  if (src.device().type() == at::kMPS && dst.device().type() == at::kMPS) {
-    return copy_kernel_mps(dst, needs_broadcasting ? src.expand_as(dst) : src, non_blocking);
-  }
   TORCH_INTERNAL_ASSERT(
       src.device().type() == DeviceType::MPS,
       "mps_copy_ is implemented only for *->MPS; MPS->*");

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -1,37 +1,22 @@
 //  Copyright © 2022 Apple Inc.
 
-#include <ATen/ATen.h>
-#include <ATen/Tensor.h>
-#include <ATen/Utils.h>
-#include <ATen/NativeFunctions.h>
-
-#include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/Copy.h>
-#include <torch/library.h>
-
-#ifdef __OBJC__
-#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#endif
-
-using namespace at::mps;
 
 namespace at::native {
 
 Scalar _local_scalar_dense_mps(const Tensor& self) {
   Scalar r;
 
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-    at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_mps", [&] {
-        Tensor output = at::empty({1}, TensorOptions(at::CPU(self.scalar_type())));
-
-        mps::mps_copy_(output, self, false);
-        scalar_t value = *output.data_ptr<scalar_t>();
-        r = Scalar(value);
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+    at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "_local_scalar_dense_mps", [&] {
+      Tensor cpu_output = at::empty({1}, TensorOptions(at::CPU(self.scalar_type())));
+      mps::mps_copy_(cpu_output, self, false);
+      scalar_t cpu_scalar = *cpu_output.data_ptr<scalar_t>();
+      r = Scalar(cpu_scalar);
    });
 
   return r;
 }
-
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -8,8 +8,8 @@ namespace at::native {
 Scalar _local_scalar_dense_mps(const Tensor& self) {
   Scalar r;
 
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
-    at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "_local_scalar_dense_mps", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+    at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_mps", [&] {
       Tensor cpu_output = at::empty({1}, TensorOptions(at::CPU(self.scalar_type())));
       mps::mps_copy_(cpu_output, self, false);
       scalar_t cpu_scalar = *cpu_output.data_ptr<scalar_t>();


### PR DESCRIPTION
- This improves the copy performance and supports both H2D and D2H Scalar copies