### PR TITLE
Enable executable caching when type inference is disabled

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -76,7 +76,7 @@ public:
                      size_t length, size_t srcOffset, size_t dstOffset,
                      bool non_blocking, uint64_t profileId);
   void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results,
-                       SyncType syncType = SyncType::NONE, bool disableTypeInference = false);
+                       SyncType syncType = SyncType::NONE, MPSGraphExecutable* executable = nullptr);
 
   void addCompletedHandler(MTLCommandBufferHandler block);
 
@@ -96,6 +96,7 @@ private:
   MPSCommandBuffer* _commandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
+  MPSGraphExecutableExecutionDescriptor *_executableExecutionDescriptor = nil;
 
   dispatch_queue_t _serialQueue = nullptr;
   // CommitAndContinue is enabled by default

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -20,6 +20,7 @@ MPSStream::MPSStream(Stream stream) : _stream(stream) {
   TORCH_CHECK(_stream.device_type() == DeviceType::MPS);
   _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
   _executionDescriptor = [MPSGraphExecutionDescriptor new];
+  _executableExecutionDescriptor = [MPSGraphExecutableExecutionDescriptor new];
   // disable commitAndContinue if Signpost tracing is enabled
   if (getMPSProfiler().isSignpostTracingEnabled()) {
     _enableCommitAndContinue = false;
@@ -176,7 +177,7 @@ void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer, 
 }
 
 void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results,
-                                SyncType syncType, bool disableTypeInference) {
+                                SyncType syncType, MPSGraphExecutable* executable) {
   auto& profiler = getMPSProfiler();
   const bool isGraphProfilingEnabled = profiler.isGraphProfilingEnabled();
 
@@ -189,21 +190,36 @@ void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDicti
         profiler.beginProfileGPUInterval(mpsGraph);
       }
 
-      if (disableTypeInference) {
-        MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
-        [compilationDescriptor disableTypeInference];
-        _executionDescriptor.compilationDescriptor = compilationDescriptor;
+      if (executable) {
+        NSMutableArray *inputsArray  = [NSMutableArray arrayWithCapacity:[feeds count]];
+        NSMutableArray *resultsArray = [NSMutableArray arrayWithCapacity:[results count]];
+        NSUInteger inputIndex = 0, ouputIndex = 0;
+        for (MPSGraphTensor *tensor in [executable feedTensors]) {
+          inputsArray[inputIndex++] = feeds[tensor];
+        }
+        
+        for (MPSGraphTensor *tensor in [executable targetTensors]) {
+          resultsArray[ouputIndex++] = results[tensor];
+        }
+
+        MPSGraphExecutableExecutionDescriptor *executionDescriptor =
+                        [[MPSGraphExecutableExecutionDescriptor new] autorelease];
+
+        executionDescriptor.completionHandler = ^(NSArray<MPSGraphTensorData *> * _Nonnull,
+                                                NSError * _Nullable) { };
+
+        [executable encodeToCommandBuffer:commandBuffer()
+                              inputsArray:inputsArray
+                             resultsArray:resultsArray
+                      executionDescriptor:_executableExecutionDescriptor];
       } else {
-        // there's no enableTypeInference, so we just need to set it to nil to
-        // re-enable type inference
-        _executionDescriptor.compilationDescriptor = nil;
+        // note: CommitAndContinue feature is enabled/disabled via "_executionDescriptor"
+        [mpsGraph encodeToCommandBuffer:commandBuffer()
+                                  feeds:feeds
+                       targetOperations:nil
+                      resultsDictionary:results
+                    executionDescriptor:_executionDescriptor];
       }
-      // note: CommitAndContinue feature is enabled/disabled via "_executionDescriptor"
-      [mpsGraph encodeToCommandBuffer:commandBuffer()
-                                feeds:feeds
-                     targetOperations:nil
-                    resultsDictionary:results
-                  executionDescriptor:_executionDescriptor];
 
       // check if graph execution profiling is enabled
       if (isGraphProfilingEnabled) {

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -32,7 +32,10 @@ MPSStream::~MPSStream() {
   [_commandQueue release];
   _commandQueue = nil;
   [_executionDescriptor release];
+  [_executableExecutionDescriptor release];
+
   _executionDescriptor = nil;
+  _executableExecutionDescriptor = nil;
 
   assert(_commandBuffer == nil);
 }
@@ -197,16 +200,10 @@ void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDicti
         for (MPSGraphTensor *tensor in [executable feedTensors]) {
           inputsArray[inputIndex++] = feeds[tensor];
         }
-        
+
         for (MPSGraphTensor *tensor in [executable targetTensors]) {
           resultsArray[ouputIndex++] = results[tensor];
         }
-
-        MPSGraphExecutableExecutionDescriptor *executionDescriptor =
-                        [[MPSGraphExecutableExecutionDescriptor new] autorelease];
-
-        executionDescriptor.completionHandler = ^(NSArray<MPSGraphTensorData *> * _Nonnull,
-                                                NSError * _Nullable) { };
 
         [executable encodeToCommandBuffer:commandBuffer()
                               inputsArray:inputsArray

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -48,7 +48,8 @@ void runMPSGraphExecutable(
   MPSStream *mpsStream,
   MPSCachedGraph* cachedraph,
   NSDictionary *feeds,
-  NSDictionary *results);
+  NSDictionary *results,
+  MPSGraphTensor* alphaTensor = nil);
 
 
 MPSDataType getMPSDataType(ScalarType scalar_type);
@@ -138,8 +139,11 @@ struct MPSCachedGraph
 
   MPSGraph *graph() const { return (MPSGraph *)_object; }
   NSObject *object() const { return _object; }
+  MPSGraphExecutable *getExecultable() const { return _executable; }
+  void setExecultable(MPSGraphExecutable *executable) { _executable = executable; }
 private:
   NSObject *_object = nullptr;
+  MPSGraphExecutable* _executable = nullptr;
 };
 
 struct MPSUnaryCachedGraph : public MPSCachedGraph

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -39,17 +39,16 @@ void runMPSGraph(
     MPSStream* mpsStream,
     MPSGraph* mpsGraph,
     NSDictionary* feeds,
-    NSDictionary* results,
-    bool disableTypeInference = false);
+    NSDictionary* results);
 
 struct MPSCachedGraph;
 
-void runMPSGraphExecutable(
+void runMPSGraph(
   MPSStream *mpsStream,
-  MPSCachedGraph* cachedraph,
+  MPSCachedGraph* cachedGraph,
   NSDictionary *feeds,
   NSDictionary *results,
-  MPSGraphTensor* alphaTensor = nil);
+  bool disableTypeInference = false);
 
 
 MPSDataType getMPSDataType(ScalarType scalar_type);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -7,34 +7,39 @@
 namespace at::native::mps {
 
 void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds,
-                 NSDictionary* results, bool disableTypeInference) {
+                 NSDictionary* results) {
   mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE);
 }
 
 // this should be merged into runMPSGraph() with new arg "disableTypeInference" for executables
-void runMPSGraphExecutable(MPSStream *mpsStream, MPSCachedGraph *cachedGraph, NSDictionary *feeds, NSDictionary *results, MPSGraphTensor* alphaTensor) {
-  @autoreleasepool {
-    MPSGraph *mpsGraph = cachedGraph->graph();
-    MPSGraphExecutable* executable = cachedGraph->getExecultable();
-    if (!executable) {
-      NSMutableDictionary* shapes = [[NSMutableDictionary new] autorelease];
-      for (MPSGraphTensor* graphTensor in feeds) {
-        MPSGraphTensorData* graphTensorData = [feeds objectForKey:graphTensor];
-        shapes[graphTensor] = [[[MPSGraphShapedType alloc] initWithShape:nil dataType:graphTensorData.dataType] autorelease];
-      }
-      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
-      [compilationDescriptor disableTypeInference];
+void runMPSGraph(MPSStream* mpsStream, MPSCachedGraph *cachedGraph, NSDictionary* feeds,
+                 NSDictionary* results, bool disableTypeInference) {
+  MPSGraphExecutable* executable = nil;
+  if (disableTypeInference) {
+    @autoreleasepool {
+      MPSGraph *mpsGraph = cachedGraph->graph();
+      MPSGraphExecutable* executable = cachedGraph->getExecultable();
+      if (!executable) {
+        NSMutableDictionary* shapes = [[NSMutableDictionary new] autorelease];
+        for (MPSGraphTensor* graphTensor in feeds) {
+          MPSGraphTensorData* graphTensorData = [feeds objectForKey:graphTensor];
+          shapes[graphTensor] = [[[MPSGraphShapedType alloc] initWithShape:nil dataType:graphTensorData.dataType] autorelease];
+        }
+        MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
+        [compilationDescriptor disableTypeInference];
 
-      executable = [[mpsGraph compileWithDevice:nil
-                                          feeds:shapes
-                                  targetTensors:[results allKeys]
-                               targetOperations:nil
-                          compilationDescriptor:compilationDescriptor] retain];
-      // store the executable within the cachedGraph to reuse next time
-      cachedGraph->setExecultable(executable);
+        executable = [[mpsGraph compileWithDevice:nil
+                                            feeds:shapes
+                                    targetTensors:[results allKeys]
+                                 targetOperations:nil
+                            compilationDescriptor:compilationDescriptor] retain];
+        // store the executable within the cachedGraph to reuse next time
+        cachedGraph->setExecultable(executable);
+      }
     }
-    mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE, executable);
   }
+
+  mpsStream->executeMPSGraph(cachedGraph->graph(), feeds, results, SyncType::COMMIT_ADAPTIVE, executable);
 }
 
 MPSDataType getMPSDataType(ScalarType scalar_type) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -8,7 +8,36 @@ namespace at::native::mps {
 
 void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds,
                  NSDictionary* results, bool disableTypeInference) {
-  mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE, disableTypeInference);
+  mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE);
+}
+
+// this should be merged into runMPSGraph() with new arg "disableTypeInference" for executables
+void runMPSGraphExecutable(MPSStream *mpsStream, MPSCachedGraph *cachedGraph, NSDictionary *feeds, NSDictionary *results, MPSGraphTensor* alphaTensor) {
+  @autoreleasepool {
+    MPSGraph *mpsGraph = cachedGraph->graph();
+    MPSGraphExecutable* executable = cachedGraph->getExecultable();
+    if (!executable) {
+      NSMutableDictionary* shapes = [[NSMutableDictionary new] autorelease];
+      for (MPSGraphTensor* graphTensor in feeds) {
+        MPSGraphTensorData* graphTensorData = [feeds objectForKey:graphTensor];
+        shapes[graphTensor] = [[[MPSGraphShapedType alloc] initWithShape:nil dataType:graphTensorData.dataType] autorelease];
+      }
+      if (alphaTensor) {
+        shapes[alphaTensor] = [[[MPSGraphShapedType alloc] initWithShape:@[@1] dataType:alphaTensor.dataType] autorelease];
+      }
+      MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
+      [compilationDescriptor disableTypeInference];
+
+      executable = [[mpsGraph compileWithDevice:nil
+                                          feeds:shapes
+                                  targetTensors:[results allKeys]
+                               targetOperations:nil
+                          compilationDescriptor:compilationDescriptor] retain];
+      // store the executable within the cachedGraph to reuse next time
+      cachedGraph->setExecultable(executable);
+    }
+    mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE, executable);
+  }
 }
 
 MPSDataType getMPSDataType(ScalarType scalar_type) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -22,9 +22,6 @@ void runMPSGraphExecutable(MPSStream *mpsStream, MPSCachedGraph *cachedGraph, NS
         MPSGraphTensorData* graphTensorData = [feeds objectForKey:graphTensor];
         shapes[graphTensor] = [[[MPSGraphShapedType alloc] initWithShape:nil dataType:graphTensorData.dataType] autorelease];
       }
-      if (alphaTensor) {
-        shapes[alphaTensor] = [[[MPSGraphShapedType alloc] initWithShape:@[@1] dataType:alphaTensor.dataType] autorelease];
-      }
       MPSGraphCompilationDescriptor *compilationDescriptor = [[MPSGraphCompilationDescriptor new] autorelease];
       [compilationDescriptor disableTypeInference];
 

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -188,8 +188,12 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results, disableTypeInference);
-
+    if (disableTypeInference) {
+      runMPSGraphExecutable(mpsStream, cachedGraph, feeds, results, cachedGraph->alphaTensor);
+    } else {
+      runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
+    }
+    
     if (needsCopyToOutput) {
       output_.copy_(output);
     }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -172,7 +172,6 @@ void reduction_out_mps(
     return;
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
   @autoreleasepool {
     std::string dtype_str = dtype.has_value() ? mps::getMPSTypeString(dtype.value()) : "";
     NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -295,11 +295,7 @@ void reduction_out_mps(
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    if (disableTypeInference) {
-      runMPSGraphExecutable(getCurrentMPSStream(), cachedGraph, feeds, results);
-    } else {
-      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
-    }
+    runMPSGraph(getCurrentMPSStream(), cachedGraph, feeds, results, disableTypeInference);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -296,7 +296,11 @@ void reduction_out_mps(
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results, disableTypeInference);
+    if (disableTypeInference) {
+      runMPSGraphExecutable(getCurrentMPSStream(), cachedGraph, feeds, results);
+    } else {
+      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    }
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -65,7 +65,11 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results, disableTypeInference);
+    if (disableTypeInference) {
+      runMPSGraphExecutable(getCurrentMPSStream(), cachedGraph, feeds, results);
+    } else {
+      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    }
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -65,11 +65,7 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    if (disableTypeInference) {
-      runMPSGraphExecutable(getCurrentMPSStream(), cachedGraph, feeds, results);
-    } else {
-      runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
-    }
+    runMPSGraph(getCurrentMPSStream(), cachedGraph, feeds, results, disableTypeInference);
   }
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6536,6 +6536,8 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 8, 4, 5), 0.1)
         helper((2, 8, 3, 5), 0.1)
         helper((2, 8, 3, 5), 0.2)
+        helper((3, 4, 5, 6, 2), 0.2)
+        helper((2), 0.2)
 
     # Test add
     def test_add_scalars(self):


### PR DESCRIPTION
Fixes perf regression in torchbench (Brings back changes from https://github.com/kulinseth/pytorch/pull/382)