### PR TITLE
Squeeze last dimensions if possible for 5D (or bigger) reductions

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -153,7 +153,7 @@ void reduction_out_mps(
   }
 
   if (input_shape.size() >= 5 && canSqueezeLastDim) {
-    for (int i = 4; i < input_shape.size(); i++) {
+    for (const auto i: c10::irange(4, input_shape.size())) {
       if (input_shape[i] != 1) {
         canSqueezeLastDim = false;
       }
@@ -165,7 +165,7 @@ void reduction_out_mps(
   MPSShape* mpsShape = getMPSShape(input_t);
   if (canSqueezeLastDim) {
     mpsShape = @[@(input_shape[0]), @(input_shape[1]), @(input_shape[2]), @(input_shape[3])];
-    input_shape = makeArrayRef(input_shape.begin(), input_shape.end() - (input_t_.dim() - 4));
+    input_shape = makeArrayRef(input_shape.begin(), input_shape.end() - (input_t.dim() - 4));
   }
 
   bool disableTypeInference = false;

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -129,7 +129,7 @@ void set_axes_and_shapes(const IntArrayRef& input_shape,
 }
 
 void reduction_out_mps(
-  const Tensor& input_t_,
+  const Tensor& input_t,
   OptionalIntArrayRef opt_dim,
   bool keepdim,
   c10::optional<ScalarType> dtype,
@@ -137,10 +137,9 @@ void reduction_out_mps(
   MPSReductionType reduction_type,
   const std::string& func_name) {
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
-  MPS_CHECK_INT64_OP_SUPPORTED(input_t_, macOS13_3_plus, func_name);
-  Tensor input_t = input_t_;
+  MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, func_name);
   bool canSqueezeLastDim = true;
-  IntArrayRef input_shape = input_t_.sizes();
+  IntArrayRef input_shape = input_t.sizes();
   if (opt_dim.has_value()) {
     IntArrayRef dim = opt_dim.value();
     for (const auto dim_val : dim) {
@@ -148,7 +147,7 @@ void reduction_out_mps(
       if (wrap_dim >= 4) {
         canSqueezeLastDim = false;
       }
-      TORCH_CHECK(wrap_dim < (input_shape.size() == 0 ? input_t_.numel() : input_shape.size()),
+      TORCH_CHECK(wrap_dim < (input_shape.size() == 0 ? input_t.numel() : input_shape.size()),
       func_name+": reduction dim must be in the range of input shape")
     }
   }

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -25,7 +25,8 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
     output.copy_(self);
     return;
   }
-  bool disableTypeInference = true;
+
+  bool disableTypeInference = (self.dim() == 1) ? true : false;
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, output}, false, disableTypeInference);


### PR DESCRIPTION
Summary of changes:
- Reduction ops optimization - squeeze all dimensions after 4th dim if they are all 1
- Disable type inference only for 1D unary ops
  