### PR TITLE
Commit more frequently on command buffers with large resources

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -18,8 +18,6 @@ namespace at {
 namespace mps {
 namespace HeapAllocator {
 
-#define MB(x) round_page(x * 1048576UL)
-
 static const size_t kMaxSmallAlloc = MB(1);    // largest "small" allocation is 1 MiB
 static const size_t kMinLargeAlloc = MB(10);   // allocations between 1 and 10 MiB may use kLargeHeap
 static const size_t kRoundLarge    = MB(2);    // round up large allocations to 2 MiB

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -6,6 +6,8 @@
 #include <c10/util/Registry.h>
 #include <ATen/core/ATen_fwd.h>
 
+#define MB(x) (x * 1048576UL)
+
 namespace at { namespace mps {
 
 // this is a public interface to access MPSAllocator.

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -63,10 +63,7 @@ public:
 
   MPSCommandBuffer* commandBuffer();
   MTLComputeCommandEncoder_t commandEncoder();
-  void commit();
   void endKernelCoalescing();
-  void commitAndWait();
-  void commitAndContinue();
   void synchronize(SyncType syncType);
   void fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
   void copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
@@ -98,12 +95,19 @@ private:
   MTLComputeCommandEncoder_t _commandEncoder = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
   MPSGraphExecutableExecutionDescriptor *_executableExecutionDescriptor = nil;
-
   dispatch_queue_t _serialQueue = nullptr;
   // CommitAndContinue is enabled by default
   bool _enableCommitAndContinue = true;
+  // accumulated sizes of resources encoded on command buffer
+  size_t _commandBufferResourceSize = 0;
 
+  // use synchronize() to access any of these commit functions outside MPSStream
+  void commit();
+  void commitAndWait();
+  void commitAndContinue();
   void flush();
+
+  void updateCommandBufferResourceSize(NSArray<MPSGraphTensorData*> *feeds);
 };
 
 /**

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -11,7 +11,6 @@
 namespace at {
 namespace mps {
 
-#define MB(x) (x * 1048576UL)
 // threshold to perform adaptive commit if the accumulated size
 // of resources encoded on the command buffer exceeds that.
 static const size_t kCmdBufAdaptiveCommitThreshold = MB(64);


### PR DESCRIPTION
- This should improve performance on some models that encode large resources onto command buffers, by committing adaptively based on the accumulated size of resources encoded.