### PR TITLE
Enable Adaptive Commit for kernel calls

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -65,6 +65,7 @@ public:
   MTLComputeCommandEncoder_t commandEncoder();
   void endKernelCoalescing();
   void synchronize(SyncType syncType);
+  void commitAdaptive(const TensorList& tensors, void* profilerHandle);
   void fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
   void copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
             size_t length, size_t srcOffset, size_t dstOffset,

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -70,7 +70,8 @@ void MPSStream::synchronize(SyncType syncType) {
       commit();
       break;
     case SyncType::COMMIT_ADAPTIVE:
-      // the adaptive commit only commits if we hit the low watermark memory threshold
+      // the adaptive commit only commits if we hit the low watermark memory threshold,
+      // or when the sizes attached to the active command buffer exceeds the threshold
       if (getIMPSAllocator()->getLowWatermarkValue() <= 0 ||
           _commandBufferResourceSize > kCmdBufAdaptiveCommitThreshold) {
         commit();
@@ -119,6 +120,20 @@ void MPSStream::commitAndWait() {
 void MPSStream::commitAndContinue() {
   assert(_commandBuffer);
   [_commandBuffer commitAndContinue];
+}
+
+void MPSStream::commitAdaptive(const TensorList& tensors, void* profilerHandle) {
+  if (_enableCommitAndContinue) {
+    for (const auto& tensor : tensors) {
+      _commandBufferResourceSize += tensor.nbytes();
+    }
+  }
+  auto& profiler = getMPSProfiler();
+  if (profiler.isOperationProfilingEnabled()) {
+    profiler.endProfileKernel(profilerHandle, SyncType::COMMIT_ADAPTIVE);
+  } else {
+    synchronize(SyncType::COMMIT_ADAPTIVE);
+  }
 }
 
 void MPSStream::endKernelCoalescing() {

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -172,7 +172,7 @@ void fmax_fmin_mps_impl(TensorIteratorBase& iter, const std::string max_min) {
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-      mpsStream->commitAdaptive({input, other}, fmaxfminPSO);
+      mpsStream->commitAdaptive({input, other, out}, fmaxfminPSO);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -172,8 +172,7 @@ void fmax_fmin_mps_impl(TensorIteratorBase& iter, const std::string max_min) {
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(fmaxfminPSO);
+      mpsStream->commitAdaptive({input, other}, fmaxfminPSO);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -194,8 +194,7 @@ void handle_tensor_tensor_binary_op(const at::Tensor& self, const at::Tensor& ot
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     [commandEncoder setBuffer:otherBuf offset:other.storage_offset()*other.itemsize() atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-
-    getMPSProfiler().endProfileKernel(cplState);
+    stream->commitAdaptive({self, other}, cplState);
   });
 }
 
@@ -228,8 +227,7 @@ void handle_tensor_scalar_binary_op(const at::Tensor& self, const at::Scalar& ot
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     [commandEncoder setBytes:&sval length:sizeof(sval) atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-
-    getMPSProfiler().endProfileKernel(cplState);
+    stream->commitAdaptive({self}, cplState);
   });
 }
 
@@ -334,8 +332,7 @@ at::Tensor& bitwise_not_out_mps (const at::Tensor& self, at::Tensor& output_) {
     [commandEncoder setBuffer:outBuf offset:output.storage_offset()*output.itemsize() atIndex:1];
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     dispatch1DJob(commandEncoder, cplState, length);
-
-    getMPSProfiler().endProfileKernel(cplState);
+    stream->commitAdaptive({self}, cplState);
   });
   if (needs_output_copy) {
       output_.copy_(output);

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -194,7 +194,7 @@ void handle_tensor_tensor_binary_op(const at::Tensor& self, const at::Tensor& ot
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     [commandEncoder setBuffer:otherBuf offset:other.storage_offset()*other.itemsize() atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-    stream->commitAdaptive({self, other}, cplState);
+    stream->commitAdaptive({self, other, output}, cplState);
   });
 }
 
@@ -227,7 +227,7 @@ void handle_tensor_scalar_binary_op(const at::Tensor& self, const at::Scalar& ot
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     [commandEncoder setBytes:&sval length:sizeof(sval) atIndex:3];
     dispatch1DJob(commandEncoder, cplState, length);
-    stream->commitAdaptive({self}, cplState);
+    stream->commitAdaptive({self, output}, cplState);
   });
 }
 
@@ -332,7 +332,7 @@ at::Tensor& bitwise_not_out_mps (const at::Tensor& self, at::Tensor& output_) {
     [commandEncoder setBuffer:outBuf offset:output.storage_offset()*output.itemsize() atIndex:1];
     [commandEncoder setBuffer:selfBuf offset:self.storage_offset()*self.itemsize()  atIndex:2];
     dispatch1DJob(commandEncoder, cplState, length);
-    stream->commitAdaptive({self}, cplState);
+    stream->commitAdaptive({self, output}, cplState);
   });
   if (needs_output_copy) {
       output_.copy_(output);

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -195,8 +195,7 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(crossPSO);
+      mpsStream->commitAdaptive({input, other}, crossPSO);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -195,7 +195,7 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-      mpsStream->commitAdaptive({input, other}, crossPSO);
+      mpsStream->commitAdaptive({input, other, out}, crossPSO);
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -153,7 +153,7 @@ bool dispatchIndexKernel(TensorIteratorBase& iter,
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-      mpsStream->commitAdaptive({inputTensor}, indexSelectPSO);
+      mpsStream->commitAdaptive({inputTensor, outputTensor}, indexSelectPSO);
     }
   });
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -153,8 +153,7 @@ bool dispatchIndexKernel(TensorIteratorBase& iter,
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreads: gridSize
                 threadsPerThreadgroup: threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(indexSelectPSO);
+      mpsStream->commitAdaptive({inputTensor}, indexSelectPSO);
     }
   });
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -823,7 +823,7 @@ Tensor& linalg_solve_triangular_mps_impl( const Tensor& A, const Tensor& B, bool
                   rightHandSideMatrix:rightHandSideMatrix
                        solutionMatrix:solutionMatrix];
       }
-      getMPSProfiler().endProfileKernel(filter);
+      mpsStream->commitAdaptive({A_, B_}, filter);
     }
   });
   return out;

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -823,7 +823,7 @@ Tensor& linalg_solve_triangular_mps_impl( const Tensor& A, const Tensor& B, bool
                   rightHandSideMatrix:rightHandSideMatrix
                        solutionMatrix:solutionMatrix];
       }
-      mpsStream->commitAdaptive({A_, B_}, filter);
+      mpsStream->commitAdaptive({A_, B_, out}, filter);
     }
   });
   return out;

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -865,8 +865,7 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
 
     MTLSize threadsPerThreadgroup = MTLSizeMake(threadsPerThreadgroup_, 1, 1);
     [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadsPerThreadgroup];
-
-    getMPSProfiler().endProfileKernel(gatherPSO);
+    mpsStream->commitAdaptive({src, output}, gatherPSO);
   });
 
   return (dst.has_storage()) ? dst : output;
@@ -928,8 +927,7 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output){
 
       MTLSize threadsPerThreadgroup = MTLSizeMake(threadsPerThreadgroup_, 1, 1);
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadsPerThreadgroup];
-
-      getMPSProfiler().endProfileKernel(scatterPSO);
+      mpsStream->commitAdaptive({src, output}, scatterPSO);
     }
   });
 


### PR DESCRIPTION
This will take into account the size of resources attached from native Kernel calls into the active command buffer, so we could commit adaptively if the accumulated sizes exceed the threshold.