### PR TITLE
Fix the completedHandler error caused by race condition in try_copy_scalars()

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -349,7 +349,10 @@ static bool try_copy_scalars_mps(at::Tensor& dst, const at::Tensor& src, bool no
                                          src, dst, length, needsSync, false);
   if (needsSync) {
     // wait for any possible GPU operations to finish before reading from source MPS buffers
-    getDefaultMPSStream()->synchronize(SyncType::COMMIT_AND_WAIT);
+    auto stream = getDefaultMPSStream();
+    dispatch_sync(stream->queue(), ^() {
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    });
   }
   memcpy((char*) dst_ptr + dst_offset, (char*) src_ptr + src_offset, length);
 


### PR DESCRIPTION
This should fix this error from command buffers which is caused by the race condition from the synchronize() call from try_copy_scalars() and the encodeToCommandBuffer() call from executeMPSGraph():
`failed assertion `Completed handler provided after commit call'`

