### PR TITLE
Enable Scalar Binary/Bitwise ops for shared buffers

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -31,6 +31,25 @@ void MPSHeapAllocatorImpl::init_allocator() {
   static const char *low_watermark_ratio_str = getenv("PYTORCH_MPS_LOW_WATERMARK_RATIO");
   const double low_watermark_ratio = low_watermark_ratio_str ? strtod(low_watermark_ratio_str, nullptr) : default_low_watermark_ratio;
   setLowWatermarkRatio(low_watermark_ratio);
+
+  // using a container for pools to simplify iterating over them
+  // Pool of large buffers with private storage mode
+  m_pools.emplace(BufferPool::Kind::PRIVATE_LARGE,
+                  std::make_unique<BufferPool>(m_device, UsageFlags::PRIVATE | UsageFlags::HAZARD));
+  // Pool of large buffers with shared storage mode
+  m_pools.emplace(BufferPool::Kind::SHARED_LARGE,
+                  std::make_unique<BufferPool>(m_device, UsageFlags::SHARED  | UsageFlags::HAZARD));
+  // Pool of small buffers with private storage mode
+  m_pools.emplace(BufferPool::Kind::PRIVATE_SMALL,
+                  std::make_unique<BufferPool>(m_device, UsageFlags::SMALL | UsageFlags::PRIVATE | UsageFlags::HAZARD));
+  // Pool of small buffers with shared storage mode
+  m_pools.emplace(BufferPool::Kind::SHARED_SMALL,
+                  std::make_unique<BufferPool>(m_device, UsageFlags::SMALL | UsageFlags::SHARED  | UsageFlags::HAZARD));
+  // Pool of small buffers with shared storage mode used to allocate and copy Scalars
+  // from CPU to Metal buffers (see allocScalarBufferWithValue()).
+  // no Hazard Tracking required for the Scalar pool (synchronized manually).
+  m_pools.emplace(BufferPool::Kind::SCALAR,
+                  std::make_unique<BufferPool>(m_device, UsageFlags::SMALL | UsageFlags::SHARED | UsageFlags::SCALAR));
 }
 
 void MPSHeapAllocatorImpl::setHighWatermarkRatio(double ratio) {
@@ -135,12 +154,12 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
   BufferPool& pool = *params.pool;
   // track buffer reuse intervals only on large pool when low watermark limit is enabled.
   if (m_low_watermark_ratio > 0.0 && !(pool.usage & UsageFlags::SMALL)) {
-    for (auto& b : pool.buffers) {
+    for (auto& b : pool.available_buffers) {
       ++b->gc_count;
     }
   }
-  auto it = pool.buffers.lower_bound(&params.search_key);
-  if (it != pool.buffers.end()) {
+  auto it = pool.available_buffers.lower_bound(&params.search_key);
+  if (it != pool.available_buffers.end()) {
     BufferBlock* buffer_block = *it;
 
     // the logic in here is simple: keep reusing existing heaps capacity as long as possible (by splitting
@@ -174,7 +193,7 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
   if (!params.buffer_block) {
     return false; // this will make allocator to allocate a new buffer
   }
-  pool.buffers.erase(params.buffer_block);
+  pool.available_buffers.erase(params.buffer_block);
   params.buffer_block->requested_size = params.requested_size;
   params.buffer_block->gc_count = 0;
   pool.available_size -= params.buffer_block->size;
@@ -257,7 +276,7 @@ void MPSHeapAllocatorImpl::free_buffer(BufferBlock* buffer_block) {
 
   BufferPool& pool = *buffer_block->heap->pool;
   // Makes sure the BufferBlock* isn't already present in the pool we're freeing it back into.
-  TORCH_INTERNAL_ASSERT(pool.buffers.insert(buffer_block).second);
+  TORCH_INTERNAL_ASSERT(pool.available_buffers.insert(buffer_block).second);
   pool.available_size += buffer_block->size;
   buffer_block->shape.clear(); // reset shape
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(m_current_allocated_memory >= buffer_block->size);
@@ -280,7 +299,7 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
   pool.allocated_size -= buffer_block->size;
   pool.available_size -= buffer_block->size;
   m_allocated_buffers.erase(buffer_block->buffer);
-  pool.buffers.erase(buffer_block);
+  pool.available_buffers.erase(buffer_block);
   pool.n_buffers--;
   // will re-insert later to keep the heaps list sorted based on heap's new available size (if heap not empty)
   pool.heaps.erase(heap_block);
@@ -333,11 +352,11 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
 }
 
 void MPSHeapAllocatorImpl::release_buffers(BufferPool& pool) {
-  if (pool.buffers.empty()) {
+  if (pool.available_buffers.empty()) {
     return;
   }
   if ((m_debug_verbosity & DebugVerbosity::RELEASES)) {
-    std::cerr << "Releasing " << pool.buffers.size()
+    std::cerr << "Releasing " << pool.available_buffers.size()
               << " buffers from "
               << ((pool.usage & UsageFlags::SMALL ) ? "small " : "large ")
               << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private")
@@ -345,8 +364,8 @@ void MPSHeapAllocatorImpl::release_buffers(BufferPool& pool) {
               << " pool (total size: " << format_size(pool.allocated_size)
               << ", #buffers: " << pool.n_buffers << ")\n";
   }
-  auto it = pool.buffers.begin();
-  while (it != pool.buffers.end()) {
+  auto it = pool.available_buffers.begin();
+  while (it != pool.available_buffers.end()) {
     BufferBlock* buffer_block = *it;
     ++it;
     release_buffer(buffer_block);
@@ -356,17 +375,17 @@ void MPSHeapAllocatorImpl::release_buffers(BufferPool& pool) {
 bool MPSHeapAllocatorImpl::release_available_cached_buffers(AllocParams& params) {
   BufferPool& pool = *params.pool;
 
-  if (pool.buffers.empty()) {
+  if (pool.available_buffers.empty()) {
     return false;
   }
-  auto it = pool.buffers.lower_bound(&params.search_key);
-  if (it == pool.buffers.end()) {
+  auto it = pool.available_buffers.lower_bound(&params.search_key);
+  if (it == pool.available_buffers.end()) {
     size_t totalReleased = 0;
     --it;
     while (totalReleased < params.search_key.size) {
       auto cur = it;
       totalReleased += (*it)->size;
-      if (it != pool.buffers.begin()) {
+      if (it != pool.available_buffers.begin()) {
         --it;
         release_buffer(*cur);
       } else {
@@ -390,17 +409,17 @@ bool MPSHeapAllocatorImpl::release_cached_buffers() {
               << ", other allocations: "
               << format_size(current_allocated_size() - m_total_allocated_memory) << ")\n";
   }
+
   // before releasing the buffers make sure the command buffer has finished.
   // we need to release the lock temporarily as synchronizing may cause deadlock with completion handlers.
   m_mutex.unlock();
-  m_stream->synchronize(SyncType::COMMIT_AND_WAIT);
+  m_stream->addCompletedHandler(^(id <MTLCommandBuffer>) { freeInactiveBuffers(); }, SyncType::COMMIT_AND_WAIT);
   m_mutex.lock();
   // Free all cached blocks to system allocator
-  release_buffers(m_large_pool_private);
-  release_buffers(m_large_pool_shared);
-  release_buffers(m_small_pool_private);
-  release_buffers(m_small_pool_shared);
-  release_buffers(m_scalar_pool);
+  for (const auto& poolIt : m_pools) {
+    BufferPool& pool = *poolIt.second;
+    release_buffers(pool);
+  }
   return true;
 }
 
@@ -417,7 +436,7 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
   unsigned int freeable_block_count = 0, freed_count = 0;
   size_t gc_reclaimed = 0;
 
-  for (auto& b : pool.buffers) {
+  for (auto& b : pool.available_buffers) {
     if (b->retainCount() <= 1) {
       total_age += b->gc_count;
       ++freeable_block_count;
@@ -435,8 +454,8 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
     block_freed = false;
     // free blocks of > avg age. Stop garbage collection if we reach below the
     // low watermark limit since re-allocation or fragmentation could be costly.
-    auto it = pool.buffers.begin();
-    while (it != pool.buffers.end() && gc_reclaimed < target_size) {
+    auto it = pool.available_buffers.begin();
+    while (it != pool.available_buffers.end() && gc_reclaimed < target_size) {
       BufferBlock* buffer_block = *it++;
       if (buffer_block->gc_count >= age_threshold && buffer_block->retainCount() <= 1) {
         block_freed = true;
@@ -453,7 +472,7 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
               << " buffers from large "
               << ((pool.usage & UsageFlags::SHARED) ? "shared" : "private")
               << " pool (total reclaimed: " << format_size(gc_reclaimed)
-              << ", #buffers: " << pool.buffers.size() << ")\n";
+              << ", #buffers: " << pool.available_buffers.size() << ")\n";
   }
 }
 
@@ -551,6 +570,11 @@ bool MPSHeapAllocatorImpl::waitForEvents(c10::ArrayRef<void*> buffers) {
         m_gpu_sync_cv.wait(lock, [&buffer_block]{ return buffer_block->gpu_sync_completed; });
         buffer_block->gpu_sync_completed = false;
         waitedForEvent |= buffer_block->retainCount() <= 1;
+      } else {
+        // even if one of the buffers weren't recorded beforehand, we return
+        // without continuing with other buffers since retainCount > 1
+        waitedForEvent = false;
+        break;
       }
     }
   }
@@ -597,24 +621,36 @@ IntArrayRef MPSHeapAllocatorImpl::getBufferShape(void* ptr) {
 }
 
 void MPSHeapAllocatorImpl::free(void* ptr) {
-  BufferBlock *buffer_block = nullptr;
-  {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-    buffer_block = get_allocated_buffer_block(ptr);
-    TORCH_INTERNAL_ASSERT(buffer_block);
-    const BufferPool& pool = *buffer_block->heap->pool;
-    if (!(pool.usage & UsageFlags::SCALAR)) {
-      free_buffer(buffer_block);
-      return;
+  BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
+  TORCH_INTERNAL_ASSERT(buffer_block);
+  BufferPool& pool = *buffer_block->heap->pool;
+
+  if ((pool.usage & UsageFlags::SCALAR) || buffer_block->retainCount() > 1) {
+    TORCH_INTERNAL_ASSERT(pool.buffers_pending_free.insert(buffer_block).second);
+  } else {
+    free_buffer(buffer_block);
+  }
+}
+
+void MPSHeapAllocatorImpl::freeInactiveBuffers() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+  for (const auto& poolIt : m_pools) {
+    BufferPool& pool = *poolIt.second;
+    if (!pool.buffers_pending_free.empty()) {
+      for (auto it = pool.buffers_pending_free.begin(), last = pool.buffers_pending_free.end(); it != last;) {
+        BufferBlock* buffer_block = *it;
+        if (buffer_block->retainCount() <= 1) {
+          it = pool.buffers_pending_free.erase(it);
+          free_buffer(buffer_block);
+        } else {
+          ++it;
+        }
+      }
     }
   }
-  // we sync the scalar pool manually with completion handler at the time buffer is
-  // freed when the MPSScalar instance goes our of scope
-  m_stream->addCompletedHandler(^(id <MTLCommandBuffer>) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    free_buffer(buffer_block);
-  });
 }
 
 void MPSHeapAllocatorImpl::emptyCache() {
@@ -691,6 +727,7 @@ public:
   bool isSharedBuffer(void* ptr) const override { return _getAllocImpl().isSharedBuffer(ptr); }
   bool isSharedStorageSupported() const override { return m_has_unified_memory; }
   void emptyCache() const override { _getAllocImpl().emptyCache(); }
+  void freeInactiveBuffers() const override { _getAllocImpl().freeInactiveBuffers(); }
   ssize_t getUnalignedBufferSize(void* ptr) const override { return _getAllocImpl().getUnalignedBufferSize(ptr); }
   id_t getBufferId(void* ptr) const override { return _getAllocImpl().getBufferId(ptr); };
   IntArrayRef getBufferShape(void* ptr) const override { return _getAllocImpl().getBufferShape(ptr); }
@@ -763,7 +800,7 @@ Tensor _pin_memory_mps(const Tensor& self, c10::optional<Device> device)
   TORCH_CHECK(shared_allocator, "unable to pin memory on a non-unified memory device");
 
   const size_t storage_size = detail::computeStorageNbytes(self.sizes(), self.strides(), self.dtype().itemsize());
-  std::cout << "Pinning memory of size " << storage_size / 1024UL << " KB\n";
+  std::cerr << "Pinning memory of size " << storage_size / 1024UL << " KB\n";
   auto storage = Storage(Storage::use_byte_size_t(), storage_size, shared_allocator, false);
   auto tensor = at::cpu::empty({0}, self.options()).set_(storage, 0, self.sizes(), self.strides());
   tensor.copy_(self);

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -16,6 +16,7 @@ class IMPSAllocator : public c10::Allocator {
 public:
   // see the comments in MPSAllocator.h for the description of these methods.
   virtual void emptyCache() const = 0;
+  virtual void freeInactiveBuffers() const = 0;
   virtual ssize_t getUnalignedBufferSize(void* ptr) const = 0;
   virtual IntArrayRef getBufferShape(void* ptr) const = 0;
   virtual id_t getBufferId(void* ptr) const = 0;

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -76,7 +76,7 @@ public:
   void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results,
                        SyncType syncType = SyncType::NONE, MPSGraphExecutable* executable = nullptr);
 
-  void addCompletedHandler(MTLCommandBufferHandler block);
+  void addCompletedHandler(MTLCommandBufferHandler block, SyncType syncType = SyncType::NONE);
   // see description for "_activeResources"
   void addActiveResource(MPSGraphTensorData* tensorData, void* buffer);
 

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -106,6 +106,7 @@ MPSGraphTensor* trunc_tensor(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
 MPSGraphTensor* convertNHWCtoNCHW(MPSGraph *mpsGraph, MPSGraphTensor* tensor);
 MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, ScalarType toType);
 MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, MPSDataType toType);
+MPSGraphTensorData* allocMPSGraphTensorData(id<MTLBuffer> buffer, MPSShape *mpsShape, MPSDataType mpsDataType);
 MPSGraphTensorData *getMPSGraphTensorData(MPSGraph* mpsGraph, MPSStream* mpsStream, const Tensor& tensor);
 MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar& scalar);
 

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -304,9 +304,7 @@ void printTensorNDArray(const Tensor& t) {
 
   // Initialize data
   id<MTLBuffer> selfBuf = getMTLBufferStorage(t);
-  MPSGraphTensorData* tdata = [[[MPSGraphTensorData alloc] initWithMTLBuffer:selfBuf
-                                                            shape:selfShape
-                                                         dataType:selfDType] autorelease];
+  MPSGraphTensorData* tdata = allocMPSGraphTensorData(selfBuf, selfShape, selfDType);
   C10_CLANG_DIAGNOSTIC_PUSH()
   #if C10_CLANG_HAS_WARNING("-Wobjc-method-access")
   C10_CLANG_DIAGNOSTIC_IGNORE("-Wobjc-method-access")
@@ -318,10 +316,7 @@ void printTensorNDArray(const Tensor& t) {
 MPSNDArray* ndArrayFromTensor(const Tensor& tensor, MPSShape *shape, MPSDataType mpsType)
 {
   id<MTLBuffer> buffer = getMTLBufferStorage(tensor);
-  MPSGraphTensorData* tmpGraphTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buffer
-                                                                                    shape:shape
-                                                                                 dataType:mpsType] autorelease];
-
+  MPSGraphTensorData* tmpGraphTensorData = allocMPSGraphTensorData(buffer, shape, mpsType);
   return [tmpGraphTensorData mpsndarray];
 }
 
@@ -359,15 +354,25 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSS
       mpsShape = getMPSShape(_tensor);
     }
 
-    _value = [[[MPSGraphTensorData alloc] initWithMTLBuffer:srcBuf
-                                                      shape:mpsShape
-                                                   dataType:mpsDataType] autorelease];
+    _value = allocMPSGraphTensorData(srcBuf, mpsShape, mpsDataType);
   }
-
   TORCH_INTERNAL_ASSERT(_value);
-  getDefaultMPSStream()->addActiveResource(_value, srcBuf);
 
   _placeholder = mpsGraphTensor;
+}
+
+MPSGraphTensorData* allocMPSGraphTensorData(id<MTLBuffer> buffer,
+                                            MPSShape *mpsShape,
+                                            MPSDataType mpsDataType) {
+  MPSGraphTensorData *tensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: buffer
+                                                                            shape: mpsShape
+                                                                         dataType: mpsDataType] autorelease];
+  TORCH_INTERNAL_ASSERT(tensorData);
+  // there's no way to get the underlying buffer from an
+  // MPSGraphTensorData or from its internal MPSNDArray.
+  // So we have to keep a mapping of them here.
+  getDefaultMPSStream()->addActiveResource(tensorData, buffer);
+  return tensorData;
 }
 
 MPSGraphTensorData *getMPSGraphTensorData(MPSGraph* mpsGraph,
@@ -379,10 +384,7 @@ MPSGraphTensorData *getMPSGraphTensorData(MPSGraph* mpsGraph,
   MPSGraphTensorData *result = nil;
   if (tensor.numel() > 0) {
     id<MTLBuffer> buf = getMTLBufferStorage(tensor);
-    result = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buf
-                                                    shape:mpsShape
-                                                 dataType:dataType]
-                                                 autorelease];
+    result = allocMPSGraphTensorData(buf, mpsShape, dataType);
   } else {
     // create empty NDArray
     MPSNDArrayDescriptor *desc = [MPSNDArrayDescriptor descriptorWithDataType:dataType
@@ -416,9 +418,7 @@ MPSGraphTensorData* getMPSGraphTensorFromScalar(MPSStream* mpsStream, MPSScalar&
   // Scalar pools are only supported on devices with unified memory
   if (mpsStream->device().hasUnifiedMemory) {
     scalar.buffer = getIMPSAllocator()->allocScalarBufferWithValue(&scalar.value, scalar.size);
-    result = [[[MPSGraphTensorData alloc] initWithMTLBuffer: scalar.getMTLBuffer()
-                                                      shape: @[@1]
-                                                   dataType: getMPSScalarType(scalar.type)] autorelease];
+    result = allocMPSGraphTensorData(scalar.getMTLBuffer(), @[@1], getMPSScalarType(scalar.type));
   } else {
     MPSNDArrayDescriptor *tensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:getMPSScalarType(scalar.type) shape:@[@1]];
     MPSNDArray *tensorNDArray = [[[MPSNDArray alloc] initWithDevice:mpsStream->device() descriptor:tensorDesc] autorelease];

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -6,6 +6,7 @@
 #include <ATen/mps/MPSStream.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/operations/BinaryKernel.h>
+#include <ATen/native/mps/operations/Scalar.h>
 #include <torch/library.h>
 #include <c10/util/Optional.h>
 #include <ATen/native/BinaryOps.h>
@@ -52,6 +53,12 @@ void binaryOpTensor(const Tensor& self, const Tensor& other, const Scalar& alpha
   // it's possible to receive empty tensors here
   if (self.numel() == 0 || other.numel() == 0) {
     return;
+  }
+
+  if (is_self_scalar && is_other_scalar) {
+    if (scalar_ops_mps(op_name, self, other, output_, ScalarOpCategories::BINARY_OPS)) {
+      return;
+    }
   }
 
   // Use strided kernels instead of gather-scatter if the tensors are non-contiguous

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -1,5 +1,6 @@
 #include <ATen/mps/MPSStream.h>
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/mps/operations/Scalar.h>
 #include <ATen/native/Resize.h>
 #include <fmt/format.h>
 #include <torch/library.h>
@@ -246,6 +247,10 @@ at::Tensor& _bitwise_op_out_mps (const at::Tensor& self, const at::Tensor& other
     needs_output_copy = true;
   }
   if (is_other_scalar && is_self_scalar) {
+    if (at::native::mps::scalar_ops_mps(op_name, self, other, output,
+                              at::native::mps::ScalarOpCategories::BITWISE_OPS)) {
+      return output_;
+    }
     if (op_name == "and") {
       output.fill_(c10::Scalar(self.item<int64_t>() & other.item<int64_t>()));
     } else if (op_name == "or") {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -88,12 +88,8 @@ void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
       });
       cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
     }
-    MPSGraphTensorData* srcData = [[[MPSGraphTensorData alloc]
-                                    initWithMTLBuffer:sourceBuffer shape:srcShape dataType:srcDType]
-                                   autorelease];
-    MPSGraphTensorData* dstData = [[[MPSGraphTensorData alloc]
-                                    initWithMTLBuffer:destBuffer shape:dstShape dataType:dstDType]
-                                   autorelease];
+    MPSGraphTensorData* srcData = allocMPSGraphTensorData(sourceBuffer, srcShape, srcDType);
+    MPSGraphTensorData* dstData = allocMPSGraphTensorData(destBuffer, dstShape, dstDType);
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{cachedGraph->inputTensor_: srcData};
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{cachedGraph->outputTensor_: dstData};
     stream->executeMPSGraph(cachedGraph->graph(), feeds, results, !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT_ADAPTIVE);

--- a/aten/src/ATen/native/mps/operations/Scalar.h
+++ b/aten/src/ATen/native/mps/operations/Scalar.h
@@ -1,0 +1,20 @@
+//  Copyright © 2023 Apple Inc.
+#pragma once
+
+#include <ATen/native/mps/OperationUtils.h>
+
+namespace at::native::mps {
+
+enum class ScalarOpCategories {
+    BINARY_OPS,
+    BITWISE_OPS,
+    // TODO: add support for Unary Ops
+};
+
+bool scalar_ops_mps(const std::string& op,
+                    const Tensor& self,
+                    const Tensor& other,
+                    const Tensor& output,
+                    ScalarOpCategories scalarOpCategory);
+
+}

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -1,7 +1,10 @@
 //  Copyright © 2022 Apple Inc.
 
-#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/native/mps/Copy.h>
+#include <ATen/native/mps/operations/Scalar.h>
+#include <ATen/Dispatch.h>
+#include <ATen/mps/MPSProfiler.h>
 
 namespace at::native {
 
@@ -19,4 +22,229 @@ Scalar _local_scalar_dense_mps(const Tensor& self) {
   return r;
 }
 
+namespace mps {
+
+enum class ScalarOpTypes {
+  UNSUPPORTED,
+  // Primary Binary Ops
+  ADD, SUB, DIV, MUL,
+  // Boolean ops
+  // Note: order is important for Boolean ops
+  LT, LE, GT, GE, NE, EQ, LOGICAL_OR, LOGICAL_AND,
+  // Bitwise Ops
+  AND, OR, XOR,
+};
+
+// returns an enum associated with the passed string name along with
+// whether the op is a boolean op or not.
+static ScalarOpTypes
+getScalarOpType(const std::string& op_name) {
+  static std::unordered_map<std::string, ScalarOpTypes> scalarOpsMap = {
+    // Primary Binary Ops
+    {"multiplication", ScalarOpTypes::MUL},
+    {"div_out_mps:",   ScalarOpTypes::DIV},
+    {"add_out_mps:",   ScalarOpTypes::ADD},
+    {"sub_out_mps:",   ScalarOpTypes::SUB},
+
+    // Bitwise ops
+    {"and", ScalarOpTypes::AND},
+    {"or" , ScalarOpTypes::OR },
+    {"xor", ScalarOpTypes::XOR},
+
+    // Boolean ops
+    {"lessThan",             ScalarOpTypes::LT,         },
+    {"lessThanOrEqualTo",    ScalarOpTypes::LE,         },
+    {"greaterThan",          ScalarOpTypes::GT,         },
+    {"greaterThanOrEqualTo", ScalarOpTypes::GE,         },
+    {"notEqual",             ScalarOpTypes::NE,         },
+    {"equal",                ScalarOpTypes::EQ,         },
+    {"logicalOR",            ScalarOpTypes::LOGICAL_OR, },
+    {"logicalAND",           ScalarOpTypes::LOGICAL_AND,},
+  };
+
+  if (scalarOpsMap.count(op_name) == 0) {
+    return ScalarOpTypes::UNSUPPORTED;
+  }
+  return scalarOpsMap[op_name];
+}
+
+#define BINARY_OP_CASE(OP_TYPE, OPERATOR) \
+  case ScalarOpTypes::OP_TYPE: \
+    return (selfValue) OPERATOR (otherValue)
+
+template<typename common_dtype, typename output_dtype>
+static output_dtype scalar_binary_ops_impl(const ScalarOpTypes scalarOpType,
+                                           const Scalar& selfScalar,
+                                           const Scalar& otherScalar) {
+  common_dtype selfValue  = selfScalar.to<common_dtype>();
+  common_dtype otherValue = otherScalar.to<common_dtype>();
+
+  switch (scalarOpType) {
+    BINARY_OP_CASE(ADD, + );
+    BINARY_OP_CASE(SUB, - );
+    BINARY_OP_CASE(MUL, * );
+    BINARY_OP_CASE(DIV, / );
+    BINARY_OP_CASE(LT , < );
+    BINARY_OP_CASE(LE , <=);
+    BINARY_OP_CASE(GT , > );
+    BINARY_OP_CASE(GE , >=);
+    BINARY_OP_CASE(NE , !=);
+    BINARY_OP_CASE(EQ , ==);
+    BINARY_OP_CASE(LOGICAL_AND, &&);
+    BINARY_OP_CASE(LOGICAL_OR , ||);
+
+    default:
+      AT_ERROR("Unknown scalar Binary operation: ", (uint32_t) scalarOpType);
+  }
+}
+
+template<typename scalar_t>
+static scalar_t scalar_bitwise_ops_impl(const ScalarOpTypes scalarOpType,
+                                        const scalar_t* selfCpuPtr,
+                                        const scalar_t* otherCpuPtr) {
+  scalar_t selfValue  = *selfCpuPtr;
+  scalar_t otherValue = *otherCpuPtr;
+
+  switch (scalarOpType) {
+    BINARY_OP_CASE(AND, &);
+    BINARY_OP_CASE(OR , |);
+    BINARY_OP_CASE(XOR, ^);
+
+    default:
+      AT_ERROR("Unknown scalar Binary operation: ", (uint32_t) scalarOpType);
+  }
+}
+
+bool scalar_ops_mps(const std::string& op, const Tensor& self, const Tensor& other,
+                    const Tensor& output, ScalarOpCategories scalarOpCategory) {
+  const auto& allocator = *at::mps::getIMPSAllocator();
+  if (!allocator.isSharedStorageSupported()) {
+    return false;
+  }
+  if (self.dim() > 0 || other.dim() > 0) {
+    return false;
+  }
+  if (!self.is_contiguous() || !other.is_contiguous() || !output.is_contiguous()) {
+    return false;
+  }
+
+  const ScalarOpTypes scalarOpType = getScalarOpType(op);
+  // fallback to Binary Ops kernels/graphs if scalar op isn't supported
+  if (scalarOpType == ScalarOpTypes::UNSUPPORTED) {
+    return false;
+  }
+  const bool isBooleanOp = scalarOpType >= ScalarOpTypes::LT && scalarOpType <= ScalarOpTypes::LOGICAL_AND;
+  ScalarType selfDType = self.scalar_type();
+  ScalarType otherDType = other.scalar_type();
+  ScalarType outputDType = output.scalar_type();
+  ScalarType commonDType = c10::promoteTypes(selfDType, otherDType);
+  if (isIntegralType(commonDType, true)) {
+    // integer inputs must be cast to float, if output is float
+    if (isFloatingType(outputDType)) {
+      commonDType = outputDType;
+    // in boolean ops with signed vs. unsigned integers, we always cast to the unsigned type
+    } else if (outputDType == ScalarType::Bool &&
+              (selfDType == ScalarType::Byte ||
+              otherDType == ScalarType::Byte)) {
+      commonDType = ScalarType::Byte;
+    }
+  }
+  // double type for CPU scalars must be downcast to be compatible with MPS
+  if (commonDType == kDouble) {
+    if (!isBooleanOp) {
+      commonDType = outputDType;
+    } else if (selfDType != kDouble) {
+      commonDType = selfDType;
+    } else if (otherDType != kDouble) {
+      commonDType = otherDType;
+    }
+  }
+
+  void* selfBuf = self.storage().data();
+  void* otherBuf = other.storage().data();
+  void* outputBuf = output.storage().data();
+  void* selfCpuPtr = selfBuf;
+  void* otherCpuPtr = otherBuf;
+  void* outputCpuPtr = outputBuf;
+
+  uint32_t selfOffset = self.storage_offset() * self.element_size();
+  uint32_t otherOffset = other.storage_offset() * other.element_size();
+
+  // note that if the retainCount > 1 for any of the input/output buffers, then there's a
+  // dependency on GPU timeline, and we cannot do the computation on CPU timeline in this method.
+  uint32_t selfRetainCount = 0;
+  uint32_t otherRetainCount = 0;
+  uint32_t outputRetainCount = 0;
+
+  if (self.is_mps()) {
+    std::tie(selfCpuPtr, selfRetainCount) = allocator.getSharedBufferPtr(selfBuf);
+    if (!selfCpuPtr) {
+      return false;
+    }
+    selfCpuPtr = (char*) selfCpuPtr + selfOffset;
+  }
+  if (other.is_mps()) {
+    std::tie(otherCpuPtr, otherRetainCount) = allocator.getSharedBufferPtr(otherBuf);
+    if (!otherCpuPtr) {
+      return false;
+    }
+    otherCpuPtr = (char*) otherCpuPtr + otherOffset;
+  }
+  std::tie(outputCpuPtr, outputRetainCount) = allocator.getSharedBufferPtr(outputBuf);
+  if (!outputCpuPtr) {
+    return false;
+  }
+
+  if (selfRetainCount > 1 || otherRetainCount > 1 || outputRetainCount > 1) {
+    bool syncedBufferEvents = allocator.waitForEvents({selfBuf, otherBuf, outputBuf});
+    if (!syncedBufferEvents) {
+      return false;
+    }
+  }
+
+  auto& profiler = getMPSProfiler();
+  const std::string& profiler_name = "scalar_" + op;
+  const bool isOperationProfilingEnabled = profiler.isCPUFallbackProfilingEnabled();
+  if (isOperationProfilingEnabled) {
+    profiler.beginProfileCPUFallback(profiler_name, {self, other, output});
+  }
+
+  if (scalarOpCategory == ScalarOpCategories::BINARY_OPS) {
+    Scalar selfScalar, otherScalar;
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, selfDType, "scalar_self_cast", [&]() {
+      selfScalar = Scalar(*(static_cast<scalar_t*>(selfCpuPtr)));
+    });
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, otherDType, "scalar_other_cast", [&]() {
+      otherScalar = Scalar(*(static_cast<scalar_t*>(otherCpuPtr)));
+    });
+
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, commonDType, "scalar_binary_ops", [&]() {
+      if (isBooleanOp) {
+        *((bool*)outputCpuPtr) =
+            scalar_binary_ops_impl<scalar_t, bool>(scalarOpType, selfScalar, otherScalar);
+      } else {
+        *((scalar_t*)outputCpuPtr) =
+            scalar_binary_ops_impl<scalar_t, scalar_t>(scalarOpType, selfScalar, otherScalar);
+      }
+    });
+
+  // bitwise ops only support integral types
+  } else if (scalarOpCategory == ScalarOpCategories::BITWISE_OPS) {
+    AT_DISPATCH_INTEGRAL_TYPES_AND(kBool, commonDType, "scalar_bitwise_ops", [&]() {
+      *((scalar_t*)outputCpuPtr) = scalar_bitwise_ops_impl<scalar_t>(scalarOpType,
+                                        static_cast<scalar_t*>(selfCpuPtr),
+                                        static_cast<scalar_t*>(otherCpuPtr));
+    });
+  } else {
+    AT_ERROR("Unsupported scalar operation type: ", (uint32_t) scalarOpCategory);
+  }
+
+  if (isOperationProfilingEnabled) {
+    profiler.endProfileCPUFallback(profiler_name);
+  }
+
+  return true;
+}
+
+} // namespace mps
 } // namespace at::native


### PR DESCRIPTION
- Defer freeing buffers until completionHandler is called and their retainCount becomes <= 1.
- Introduce INCLUDE_BUFFER_ID option for MPSProfiler to assist debugging buffers that are involved with various ops.
- Refactor code for allocating MPSGraphTensorData to enable associating them with their underlying metal buffers
- Use lists for buffer pools to simplify iterating over the pools

