### PR TITLE
Fix the memory growth caused by retaining inactive buffers

### DIFF
--- a/aten/src/ATen/mps/MPSProfiler.h
+++ b/aten/src/ATen/mps/MPSProfiler.h
@@ -366,6 +366,8 @@ public:
   // stats logging could run either from destructor or signal handler
   // so this is used to check if logging has already started.
   std::atomic_bool hasLoggedStats{false};
+  // indicates there are pending completionHandler callbacks that haven't been called yet.
+  std::atomic_bool hasPendingCompletionHandlers{false};
   // used to capture sigint signal to log profiling stats
   static struct sigaction currentSigint, previousSigint;
 

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -128,6 +128,8 @@ void MPSStream::commitAndWait() {
     }
     // reset the accumulated resource sizes for command buffer
     _commandBufferResourceSize = 0;
+    // after waiting, it's a good time to free some pending inactive buffers
+    getIMPSAllocator()->freeInactiveBuffers();
   }
 }
 


### PR DESCRIPTION
- The growth was caused by a previous PR where we retained buffers longer than needed in the pending free state

