### PR TITLE
[Downstream] Add C++ API support for MPS backend (#96668)

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -715,6 +715,7 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/enum.cpp",
     "torch/csrc/api/src/imethod.cpp",
     "torch/csrc/api/src/jit.cpp",
+    "torch/csrc/api/src/mps.cpp",
     "torch/csrc/api/src/serialize.cpp",
     "torch/csrc/api/src/nn/init.cpp",
     "torch/csrc/api/src/nn/module.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -704,6 +704,7 @@ if(NOT NO_API AND NOT BUILD_LITE_INTERPRETER)
     ${TORCH_SRC_DIR}/csrc/api/src/imethod.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/serialize.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
+    ${TORCH_SRC_DIR}/csrc/api/src/mps.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/init.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/module.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/_functions.cpp

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -11,6 +11,7 @@
 #include <torch/fft.h>
 #include <torch/jit.h>
 #include <torch/linalg.h>
+#include <torch/mps.h>
 #include <torch/nested.h>
 #include <torch/nn.h>
 #include <torch/optim.h>

--- a/torch/csrc/api/include/torch/mps.h
+++ b/torch/csrc/api/include/torch/mps.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <torch/csrc/Export.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace torch {
+namespace mps {
+
+/// Returns true if MPS device is available.
+bool TORCH_API is_available();
+
+/// Sets the RNG seed for the MPS device.
+void TORCH_API manual_seed(uint64_t seed);
+
+/// Waits for all streams on a MPS device to complete.
+void TORCH_API synchronize();
+
+} // namespace mps
+} // namespace torch

--- a/torch/csrc/api/src/mps.cpp
+++ b/torch/csrc/api/src/mps.cpp
@@ -1,0 +1,33 @@
+#include <torch/mps.h>
+
+#include <ATen/Context.h>
+#include <c10/util/irange.h>
+
+#include <cstddef>
+
+namespace torch {
+namespace mps {
+
+bool is_available() {
+  return at::detail::getMPSHooks().hasMPS();
+}
+
+/// Sets the seed for the MPS's default generator.
+void manual_seed(uint64_t seed) {
+  if (is_available()) {
+    auto gen = at::detail::getMPSHooks().getDefaultMPSGenerator();
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(gen.mutex());
+      gen.set_current_seed(seed);
+    }
+  }
+}
+
+void synchronize() {
+  TORCH_CHECK(is_available(), "No MPS devices are available");
+  at::detail::getMPSHooks().deviceSynchronize();
+}
+
+} // namespace mps
+} // namespace torch


### PR DESCRIPTION
This is a downstream of the already approved PR: #96668

- This enables the APIs `torch::mps::is_available()/synchronize()/manual_seed()` for use in PyTorch C++.
- Added test case for C++ APIs to `mps_test_allocator.cpp`