### PR TITLE
Add support for Custom Kernels

### DIFF
--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -41,7 +41,16 @@ struct TORCH_API MPSHooksInterface {
   virtual Allocator* getMPSDeviceAllocator() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void deviceSynchronize() const {
+  virtual void synchronizeStream() const {
+    FAIL_MPSHOOKS_FUNC(__func__);
+  }
+  virtual void commitStream() const {
+    FAIL_MPSHOOKS_FUNC(__func__);
+  }
+  virtual void* getCommandBuffer() const {
+    FAIL_MPSHOOKS_FUNC(__func__);
+  }
+  virtual void* getDispatchQueue() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
   virtual void emptyCache() const {

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -80,7 +80,6 @@ class TORCH_API MPSDevice {
 
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
-TORCH_API void device_synchronize();
 TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
 
 } // namespace mps

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -135,9 +135,5 @@ bool is_macos_13_or_newer(MacOSVersion version) {
   return MPSDevice::getInstance()->isMacOS13Plus(version);
 }
 
-void device_synchronize() {
-  getDefaultMPSStream()->synchronize(SyncType::COMMIT_AND_WAIT);
-}
-
 } // namespace mps
 } // namespace at

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -20,7 +20,10 @@ struct MPSHooks : public at::MPSHooksInterface {
   const Generator& getDefaultMPSGenerator() const override;
 
   // MPSStream interface
-  void deviceSynchronize() const override;
+  void synchronizeStream() const override;
+  void commitStream() const override;
+  void* getCommandBuffer() const override;
+  void* getDispatchQueue() const override;
 
   // MPSAllocator interface
   Allocator* getMPSDeviceAllocator() const override;

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -40,8 +40,20 @@ const Generator& MPSHooks::getDefaultMPSGenerator() const {
   return at::mps::detail::getDefaultMPSGenerator();
 }
 
-void MPSHooks::deviceSynchronize() const {
-  at::mps::device_synchronize();
+void MPSHooks::synchronizeStream() const {
+  at::mps::getDefaultMPSStream()->synchronize(SyncType::COMMIT_AND_WAIT);
+}
+
+void MPSHooks::commitStream() const {
+  at::mps::getDefaultMPSStream()->synchronize(SyncType::COMMIT);
+}
+
+void* MPSHooks::getCommandBuffer() const {
+  return at::mps::getDefaultMPSStream()->commandBuffer();
+}
+
+void* MPSHooks::getDispatchQueue() const {
+  return at::mps::getDefaultMPSStream()->queue();
 }
 
 void MPSHooks::emptyCache() const {

--- a/torch/csrc/api/include/torch/mps.h
+++ b/torch/csrc/api/include/torch/mps.h
@@ -5,6 +5,16 @@
 #include <cstddef>
 #include <cstdint>
 
+#ifdef __OBJC__
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+typedef id<MTLCommandBuffer> MTLCommandBuffer_t;
+#else
+typedef void* MTLCommandBuffer_t;
+typedef void* MTLCommandBuffer;
+typedef void* dispatch_queue_t;
+#endif
+
 namespace torch {
 namespace mps {
 
@@ -16,6 +26,16 @@ void TORCH_API manual_seed(uint64_t seed);
 
 /// Waits for all streams on a MPS device to complete.
 void TORCH_API synchronize();
+
+/// Submits the command buffer to run on the GPU
+void TORCH_API commit();
+
+/// Get the current command buffer to encode the Metal commands
+MTLCommandBuffer_t TORCH_API get_command_buffer();
+
+/// Get the dispatch_queue_t to synchronize encoding the custom kernels
+/// with the PyTorch MPS backend
+dispatch_queue_t TORCH_API get_dispatch_queue();
 
 } // namespace mps
 } // namespace torch

--- a/torch/csrc/api/src/mps.cpp
+++ b/torch/csrc/api/src/mps.cpp
@@ -26,7 +26,20 @@ void manual_seed(uint64_t seed) {
 
 void synchronize() {
   TORCH_CHECK(is_available(), "No MPS devices are available");
-  at::detail::getMPSHooks().deviceSynchronize();
+  at::detail::getMPSHooks().synchronizeStream();
+}
+
+void commit() {
+  TORCH_CHECK(is_available(), "No MPS devices are available");
+  at::detail::getMPSHooks().commitStream();
+}
+
+MTLCommandBuffer_t get_command_buffer() {
+  return static_cast<MTLCommandBuffer_t>(at::detail::getMPSHooks().getCommandBuffer());
+}
+
+dispatch_queue_t get_dispatch_queue() {
+  return static_cast<dispatch_queue_t>(at::detail::getMPSHooks().getDispatchQueue());
 }
 
 } // namespace mps

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -75,7 +75,7 @@ static PyObject* MPSModule_isMacOS13orNewer(PyObject* _unused, PyObject* args) {
 
 static PyObject* MPSModule_synchronize(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  at::detail::getMPSHooks().deviceSynchronize();
+  at::detail::getMPSHooks().synchronizeStream();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
This change adds the following C++ APIs for MPS backend: 
`torch::mps::get_command_buffer()`
`torch::mps::get_dispatch_queue()`
`torch::mps::commit()`