### PR TITLE
Fix memory growth regression caused by retaining command buffers

### DIFF
--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -121,19 +121,10 @@ void MPSStream::commitAndWait() {
   }
 
   if (_commandBuffer) {
-    if (_enableCommitAndContinue) {
-      // no need to release the command buffer with CommitAndContinue
-      // This improves the performance by eliminating the overhead of recreating
-      // command buffers, and avoiding distruption to commitAndContinue's internal cache
-      id<MTLCommandBuffer> rootCommandBuffer = _commandBuffer.rootCommandBuffer;
-      [_commandBuffer commitAndContinue];
-      [rootCommandBuffer waitUntilCompleted];
-    } else {
-      [_commandBuffer commit];
-      [_commandBuffer waitUntilCompleted];
-      [_commandBuffer release];
-      _commandBuffer = nil;
-    }
+    [_commandBuffer commit];
+    [_commandBuffer waitUntilCompleted];
+    [_commandBuffer release];
+    _commandBuffer = nil;
     // reset the accumulated resource sizes for command buffer
     _commandBufferResourceSize = 0;
     // after waiting, it's a good time to free some pending inactive buffers


### PR DESCRIPTION
- This change reverts a regression that was caused by a previous change to retain the command buffers after waitUntilCompleted call when commitAndContinue was enabled.
That regression caused the command buffers to retain references to the buffers and cause the memory to grow. 

