### PR TITLE
Add "log_stats" mode to torch.mps.profiler.start()

### DIFF
--- a/aten/src/ATen/mps/MPSProfiler.h
+++ b/aten/src/ATen/mps/MPSProfiler.h
@@ -328,7 +328,8 @@ public:
   // this enables generating OS Signpost traces from MPSProfiler on-demand
   // during runtime (instead of environment variables).
   // The "mode" could be either "interval", "event", or both "interval,event"
-  // for interval-based and/or event-based signpost tracing.
+  // for interval-based and/or event-based signpost tracing, or "log_stats"
+  // to log the profiling statistics after process's termination.
   void StartTrace(const string& mode, bool waitUntilCompleted);
   void StopTrace();
 
@@ -355,6 +356,7 @@ public:
   uint32_t m_signpost_types = 0;
   uint32_t m_profile_options = 0;
   uint32_t m_log_options = 0;
+  uint32_t m_log_api_options = 0;
   uint64_t m_kernel_counter = 0;
   uint64_t m_graph_counter = 0;
   uint64_t m_cpu_fb_counter = 0;

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -150,9 +150,13 @@ void MPSProfiler::StartTrace(const string& mode, bool waitUntilCompleted) {
   while (getline(ss, token, ',')) {
     if (!token.empty()) {
       if (token == "interval") {
-         m_profile_options |= ProfileOptions::ALL_SIGNPOST_INTERVALS;
+        m_profile_options |= ProfileOptions::ALL_SIGNPOST_INTERVALS;
       } else if (token == "event") {
         m_profile_options |= ProfileOptions::ALL_SIGNPOST_EVENTS;
+      } else if (token == "log_stats") {
+        m_log_api_options |= LogOptions::ALL_STATS;
+        // keep m_log_api_options separately to avoid conflicts with env-var log settings
+        m_log_options |= m_log_api_options;
       } else {
         AT_ERROR("Invalid Signpost trace mode: ", token);
       }
@@ -169,6 +173,9 @@ void MPSProfiler::StartTrace(const string& mode, bool waitUntilCompleted) {
 void MPSProfiler::StopTrace() {
   m_profile_options = ProfileOptions::OPTIONS_NONE;
   m_signpost_types = SignpostTypes::SIGNPOST_NONE;
+  // only disable log options that were enabled via the APIs and not env-vars
+  m_log_options &= ~m_log_api_options;
+  m_log_api_options = LogOptions::LOG_NONE;
 }
 
 void MPSProfiler::beginProfileExecution(BaseInfo& info, bool cpuExecution) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6477,7 +6477,7 @@ class TestNLLLoss(TestCaseMPS):
         x = net1(x)
         torch.mps.profiler.stop()
 
-        torch.mps.profiler.start(mode="interval", wait_until_completed=True)
+        torch.mps.profiler.start(mode="interval,log_stats", wait_until_completed=True)
         # just running some ops to capture the OS Signposts traces for profiling
         x = torch.rand(1, 128, 6, 6, device='mps', dtype=torch.float, requires_grad=True)
         x = net1(x)

--- a/torch/mps/profiler.py
+++ b/torch/mps/profiler.py
@@ -11,10 +11,11 @@ def start(mode: str = "interval", wait_until_completed: bool = False) -> None:
 
     Args:
         mode(str): OS Signpost tracing mode could be "interval", "event",
-            or both "interval,event".
+            "log_stats" or a combination of them (e.g., "interval,event").
             The interval mode traces the duration of execution of the operations,
             whereas event mode marks the completion of executions.
             See document `Recording Performance Data`_ for more info.
+            use "log_stats" to log the profiling statistics after process's termination.
         wait_until_completed(bool): Waits until the MPS Stream complete
             executing each encoded GPU operation. This helps generating single
             dispatches on the trace's timeline.
@@ -36,10 +37,11 @@ def profile(mode: str = "interval", wait_until_completed: bool = False):
 
     Args:
     mode(str): OS Signpost tracing mode could be "interval", "event",
-        or both "interval,event".
+        "log_stats" or a combination of them (e.g., "interval,event").
         The interval mode traces the duration of execution of the operations,
         whereas event mode marks the completion of executions.
         see document `Recording Performance Data`_ for more info.
+        use "log_stats" to log the profiling statistics after process's termination.
     wait_until_completed(bool): Waits until the MPS Stream complete
         executing each encoded GPU operation. This helps generating single
         dispatches on the trace's timeline.


### PR DESCRIPTION
This enables logging stats when the process terminates only for a specific scope of Python code
