### PR TITLE
Fix a bug in disableTypeInference code

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -48,7 +48,8 @@ void runMPSGraph(
   MPSCachedGraph* cachedGraph,
   NSDictionary *feeds,
   NSDictionary *results,
-  bool disableTypeInference = false);
+  bool disableTypeInference = false,
+  SyncType syncType = SyncType::COMMIT_ADAPTIVE);
 
 
 MPSDataType getMPSDataType(ScalarType scalar_type);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -13,12 +13,12 @@ void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds,
 
 // this should be merged into runMPSGraph() with new arg "disableTypeInference" for executables
 void runMPSGraph(MPSStream* mpsStream, MPSCachedGraph *cachedGraph, NSDictionary* feeds,
-                 NSDictionary* results, bool disableTypeInference) {
+                 NSDictionary* results, bool disableTypeInference, SyncType syncType) {
   MPSGraphExecutable* executable = nil;
   if (disableTypeInference) {
     @autoreleasepool {
       MPSGraph *mpsGraph = cachedGraph->graph();
-      MPSGraphExecutable* executable = cachedGraph->getExecultable();
+      executable = cachedGraph->getExecultable();
       if (!executable) {
         NSMutableDictionary* shapes = [[NSMutableDictionary new] autorelease];
         for (MPSGraphTensor* graphTensor in feeds) {
@@ -39,7 +39,7 @@ void runMPSGraph(MPSStream* mpsStream, MPSCachedGraph *cachedGraph, NSDictionary
     }
   }
 
-  mpsStream->executeMPSGraph(cachedGraph->graph(), feeds, results, SyncType::COMMIT_ADAPTIVE, executable);
+  mpsStream->executeMPSGraph(cachedGraph->graph(), feeds, results, syncType, executable);
 }
 
 MPSDataType getMPSDataType(ScalarType scalar_type) {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -92,7 +92,9 @@ void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
     MPSGraphTensorData* dstData = allocMPSGraphTensorData(destBuffer, dstShape, dstDType);
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{cachedGraph->inputTensor_: srcData};
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{cachedGraph->outputTensor_: dstData};
-    stream->executeMPSGraph(cachedGraph->graph(), feeds, results, !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT_ADAPTIVE);
+
+    runMPSGraph(stream, cachedGraph, feeds, results, /*disable_type_inference*/ true,
+                !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT_ADAPTIVE);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -571,7 +571,7 @@ Tensor& bmm_out_mps_impl(
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    mps::runMPSGraph(stream, cachedGraph, feeds, results, /*disable_type_inference*/ true);
   }
 
   return result;

--- a/aten/src/ATen/native/mps/operations/Shape.mm
+++ b/aten/src/ATen/native/mps/operations/Shape.mm
@@ -447,7 +447,7 @@ TORCH_IMPL_FUNC(cat_out_mps)
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    runMPSGraph(getCurrentMPSStream(), cachedGraph, feeds, results, /*disable_type_inference*/ true);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -162,7 +162,7 @@ TORCH_IMPL_FUNC(softmax_mps_out)
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph, feeds, results, /*disable_type_inference*/ true);
   }
 
 }


### PR DESCRIPTION
Also disable type inference for the unranked bmm, softmax, cat, and copy_cast ops

