### PR TITLE
Handle transposes in second batch of matrices in bmm

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -63,12 +63,12 @@ id<MTLLibrary> compileCopyCastOpsLibrary(id<MTLDevice> device,
   NSError *error = nil;
   MTLCompileOptions *options = [[MTLCompileOptions new] autorelease];
   [options setLanguageVersion: MTLLanguageVersion2_3];
-  auto gatherScatterLib = [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(COPY_CAST_OP_TEMPLATE_TENSOR, dtypeSrc, dtypeDst).c_str()]
+  auto copyCastLib = [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(COPY_CAST_OP_TEMPLATE_TENSOR, dtypeSrc, dtypeDst).c_str()]
                                                options:options
                                                  error:&error];
-  TORCH_CHECK(gatherScatterLib != nil && error == nil, "Failed to compile gather-scatter library, error: ", [[error description] UTF8String]);
-  _libCache[key] = gatherScatterLib;
-  return gatherScatterLib;
+  TORCH_CHECK(copyCastLib != nil && error == nil, "Failed to compile copy cast library, error: ", [[error description] UTF8String]);
+  _libCache[key] = copyCastLib;
+  return copyCastLib;
 }
 
 static id<MTLComputePipelineState> getPipelineState(id<MTLDevice> device,

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1,3 +1,4 @@
+
 //  Copyright © 2022 Apple Inc.
 
 #include <ATen/native/mps/OperationUtils.h>
@@ -570,9 +571,9 @@ Tensor& bmm_out_mps_impl(
 
           if (doTranspose) {
             batch2TensorTranspose = [mpsGraph transposeTensor:batch2Tensor
-                                                        dimension:1
-                                                    withDimension:2
-                                                              name:nil];
+                                                    dimension:1
+                                                withDimension:2
+                                                         name:nil];
           }
           MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor
                                                                           secondaryTensor:batch2TensorTranspose

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -537,7 +537,6 @@ Tensor& bmm_out_mps_impl(
   // Handle transposes for the second batch of matrices (batch2).
   if (batch2.is_view() || batch2.storage_offset()) {
     if (batch2.numel() == batch2._base().numel()) {
-      const IntArrayRef& baseSizes = batch2._base().sizes();
       const IntArrayRef& viewSizes = batch2.sizes();
 
       // Handle 3D and 4D tensors.

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -534,8 +534,8 @@ Tensor& bmm_out_mps_impl(
   MPSShape* shape = nil;
   bool doTranspose = false;
 
-  // Handle transposes for the second batch of matrices (batch2).
-  if (batch2.is_view() || batch2.storage_offset()) {
+  // Handle transposes for the second batch of matrices.
+  if (batch2.is_view() && !batch2.is_contiguous()) {
     if (batch2.numel() == batch2._base().numel()) {
       const IntArrayRef& viewSizes = batch2.sizes();
 
@@ -570,8 +570,8 @@ Tensor& bmm_out_mps_impl(
 
           if (doTranspose) {
             batch2TensorTranspose = [mpsGraph transposeTensor:batch2Tensor
-                                                    dimension:1
-                                                withDimension:2
+                                                    dimension:-1
+                                                withDimension:-2
                                                          name:nil];
           }
           MPSGraphTensor* productTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:batch1Tensor

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -533,7 +533,7 @@ Tensor& bmm_out_mps_impl(
   MPSShape* shape = nil;
   bool doTranspose = false;
 
-  // Handle transposes for the second batch of matrices.
+  // Handle transposes for the second batch of matrices (batch2).
   if (batch2.is_view() || batch2.storage_offset()) {
     if (batch2.numel() == batch2._base().numel()) {
       const IntArrayRef& baseSizes = batch2._base().sizes();


### PR DESCRIPTION
Handle transposes in second batch of matrices in `bmm` op.

Improves `bmm` op perf if second matrix is transposed (row by row matrix multiplication is much faster compared to row by column since all memory is contiguous / no strided accesses are performed).